### PR TITLE
feat: multi-clip stitching, D-Log grading, and git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if we're in a nix environment
+if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
+    # Use nix develop for consistent environment
+    if ! nix develop -c cargo fmt --check 2>/dev/null; then
+        echo "❌ Code is not formatted. Please run 'nix develop -c cargo fmt' before committing."
+        echo ""
+        echo "To see what needs formatting:"
+        echo "  nix develop -c cargo fmt --check --verbose"
+        exit 1
+    fi
+else
+    # Fallback to regular cargo
+    if ! cargo fmt --check 2>/dev/null; then
+        echo "❌ Code is not formatted. Please run 'cargo fmt' before committing."
+        echo ""
+        echo "To see what needs formatting:"
+        echo "  cargo fmt --check --verbose"
+        exit 1
+    fi
+fi
+
+echo "✅ Code formatting check passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔍 Running pre-push checks..."
+echo ""
+
+# Check if we're in a nix environment
+if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
+    # Check formatting
+    echo "📝 Checking code formatting..."
+    if ! nix develop -c cargo fmt --check 2>/dev/null; then
+        echo ""
+        echo "❌ Code is not formatted. Please run 'nix develop -c cargo fmt' before pushing."
+        echo ""
+        echo "To see what needs formatting:"
+        echo "  nix develop -c cargo fmt --check --verbose"
+        exit 1
+    fi
+    echo "✅ Formatting check passed"
+    echo ""
+    
+    # Run clippy
+    echo "🔎 Running clippy linting..."
+    if ! nix develop -c cargo clippy --workspace -- -D warnings 2>&1; then
+        echo ""
+        echo "❌ Clippy found issues. Please fix them before pushing."
+        echo ""
+        echo "To see all issues:"
+        echo "  nix develop -c cargo clippy --workspace"
+        echo ""
+        echo "To attempt automatic fixes:"
+        echo "  nix develop -c cargo clippy --workspace --fix --allow-dirty"
+        exit 1
+    fi
+    echo "✅ Clippy check passed"
+else
+    # Fallback to regular cargo
+    echo "📝 Checking code formatting..."
+    if ! cargo fmt --check 2>/dev/null; then
+        echo ""
+        echo "❌ Code is not formatted. Please run 'cargo fmt' before pushing."
+        echo ""
+        echo "To see what needs formatting:"
+        echo "  cargo fmt --check --verbose"
+        exit 1
+    fi
+    echo "✅ Formatting check passed"
+    echo ""
+    
+    # Run clippy
+    echo "🔎 Running clippy linting..."
+    if ! cargo clippy --workspace -- -D warnings 2>&1; then
+        echo ""
+        echo "❌ Clippy found issues. Please fix them before pushing."
+        echo ""
+        echo "To see all issues:"
+        echo "  cargo clippy --workspace"
+        echo ""
+        echo "To attempt automatic fixes:"
+        echo "  cargo clippy --workspace --fix --allow-dirty"
+        exit 1
+    fi
+    echo "✅ Clippy check passed"
+fi
+
+echo ""
+echo "✅ All pre-push checks passed! Proceeding with push..."
+echo ""

--- a/README.md
+++ b/README.md
@@ -89,6 +89,53 @@ List all presets with: `speedy --list-presets`
 
 ## Development
 
+This project uses Git hooks for maintaining code quality. When you enter the development environment, hooks are automatically configured:
+
+```bash
+$ nix develop
+📎 Setting up Git hooks for code quality checks...
+✅ Git hooks configured automatically!
+   • pre-commit: Checks code formatting
+   • pre-push: Runs formatting and clippy checks
+```
+
+### Git Hooks
+
+The project includes two Git hooks that help maintain code quality:
+
+1. **pre-commit**: Ensures code is properly formatted before committing
+2. **pre-push**: Runs both formatting and clippy checks before pushing
+
+These hooks are automatically configured when you enter the nix development shell. To manually configure them:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To disable the hooks temporarily:
+
+```bash
+git config --unset core.hooksPath
+```
+
+### Running Checks Manually
+
+You can run the quality checks manually at any time:
+
+```bash
+# Check formatting
+nix develop -c cargo fmt --check
+
+# Fix formatting
+nix develop -c cargo fmt
+
+# Run clippy
+nix develop -c cargo clippy --workspace -- -D warnings
+
+# Run all checks
+nix develop -c cargo fmt --check && nix develop -c cargo clippy --workspace -- -D warnings
+```
+
 ### Workspace Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project is organized as a Rust workspace with two main crates:
 ## Features
 
 - **Speed Adjustment**: Speed up or slow down videos with automatic audio pitch correction
+- **Clip Stitching**: Combine multiple clips (or a whole folder) into one output, normalizing differing resolutions/orientations to a common frame
 - **Color Grading**: Apply LUTs (Look-Up Tables) for professional color grading
 - **Advanced Color Enhancement**:
   - Vibrance (intelligent saturation that protects skin tones)
@@ -53,8 +54,26 @@ speedy -i input.mp4 -o output.mp4 --speed 2.0
 # Apply a LUT file
 speedy -i input.mp4 -o output.mp4 --lut color_grade.cube
 
-# Use a preset for DJI D-Log footage
-speedy -i drone_footage.mp4 -o processed.mp4 --preset dji-dlog
+# Use a preset for DJI Mavic 4 Pro D-Log footage
+speedy -i drone_footage.mp4 -o processed.mp4 --preset mavic4pro-dlog
+```
+
+### Stitching Multiple Clips
+
+Pass several inputs (or a directory) to stitch them into a single output, in
+order. Clips of different resolution or orientation are normalized to a common
+frame (scaled to fit and padded), so mixed 4K/6K and portrait/landscape footage
+can be combined. Any color grading is applied once over the joined timeline.
+
+> Note: stitched output is currently video-only — audio tracks are not
+> concatenated.
+
+```bash
+# Stitch specific clips, in the given order
+speedy -i clip1.mp4 clip2.mp4 clip3.mp4 -o combined.mp4
+
+# Stitch every video in a folder (sorted by filename) and grade from D-Log
+speedy -i /path/to/DCIM/DJI_001 --preset mavic4pro-dlog -o combined.mp4
 ```
 
 ### Advanced Color Grading
@@ -72,7 +91,7 @@ speedy -i input.mp4 -o output.mp4 --color-balance "0.1:-0.1:0,0:0:0,-0.1:0:0.1"
 
 ### Available Presets
 
-- `dji-dlog`: DJI drone footage with D-Log profile
+- `mavic4pro-dlog`: DJI Mavic 4 Pro footage with D-Log profile
 - `dji`: DJI drone standard footage
 - `gopro`: GoPro action camera
 - `sony-slog`: Sony S-Log footage

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,21 @@
           RUST_LOG = "info";
           
           shellHook = ''
+            # Set up Git hooks if not already configured
+            if [ -d .git ] && [ -d .githooks ]; then
+              current_hooks_path=$(git config core.hooksPath || echo "")
+              if [ "$current_hooks_path" != ".githooks" ]; then
+                echo "📎 Setting up Git hooks for code quality checks..."
+                git config core.hooksPath .githooks
+                echo "✅ Git hooks configured automatically!"
+                echo "   • pre-commit: Checks code formatting"
+                echo "   • pre-push: Runs formatting and clippy checks"
+                echo ""
+                echo "To disable: git config --unset core.hooksPath"
+                echo ""
+              fi
+            fi
+            
             echo "Welcome to Speedy development environment!"
             echo ""
             echo "FFmpeg version:"

--- a/speedy-cli/src/main.rs
+++ b/speedy-cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use clap::Parser;
-use std::path::PathBuf;
+use clap::{CommandFactory, FromArgMatches, Parser};
+use std::path::{Path, PathBuf};
 
 use speedy_core::{ColorProfile, Preset, VideoProcessor, check_ffmpeg};
 
@@ -11,9 +11,10 @@ use speedy_core::{ColorProfile, Preset, VideoProcessor, check_ffmpeg};
 )]
 #[command(version)]
 struct Args {
-    /// Input video file path
-    #[arg(short, long, required_unless_present = "list_presets")]
-    input: Option<PathBuf>,
+    /// Input video file(s) or a directory. Pass several to stitch them together
+    /// in order; a directory is expanded to its video files sorted by name.
+    #[arg(short, long, required_unless_present = "list_presets", num_args = 1..)]
+    input: Vec<PathBuf>,
 
     /// Output video file path
     #[arg(short, long, required_unless_present = "list_presets")]
@@ -115,7 +116,8 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    let args = Args::parse();
+    let matches = Args::command().get_matches();
+    let args = Args::from_arg_matches(&matches)?;
 
     // Initialize logging
     if args.verbose {
@@ -131,7 +133,7 @@ fn main() -> Result<()> {
         for (name, description) in Preset::list_all() {
             println!("{:<15} - {}", name, description);
         }
-        println!("\nUsage: speedy -i input.mp4 -o output.mp4 --preset dji-dlog");
+        println!("\nUsage: speedy -i input.mp4 -o output.mp4 --preset mavic4pro-dlog");
         return Ok(());
     }
 
@@ -154,18 +156,20 @@ fn main() -> Result<()> {
         }
     }
 
-    // Get input and output paths (they must exist if we get here)
-    let input = args
-        .input
-        .ok_or_else(|| anyhow::anyhow!("Input file required"))?;
+    // Resolve inputs: expand any directories into sorted video files.
+    let inputs = resolve_inputs(&args.input)?;
+    if inputs.is_empty() {
+        anyhow::bail!("No input video files found");
+    }
+    for file in &inputs {
+        if !file.exists() {
+            anyhow::bail!("Input file does not exist: {:?}", file);
+        }
+    }
+
     let output = args
         .output
         .ok_or_else(|| anyhow::anyhow!("Output file required"))?;
-
-    // Validate input file
-    if !input.exists() {
-        anyhow::bail!("Input file does not exist: {:?}", input);
-    }
 
     // Create output directory if it doesn't exist
     if let Some(parent) = output.parent() {
@@ -173,13 +177,18 @@ fn main() -> Result<()> {
     }
 
     log::info!("Starting video processing...");
-    log::info!("Input: {:?}", input);
+    if inputs.len() == 1 {
+        log::info!("Input: {:?}", inputs[0]);
+    } else {
+        log::info!("Inputs ({}): {:?}", inputs.len(), inputs);
+    }
     log::info!("Output: {:?}", output);
 
     // Create video processor
-    let mut processor = VideoProcessor::new(&input, &output);
+    let mut processor = VideoProcessor::new_multi(inputs, &output);
 
     // Apply preset if specified
+    let preset_used = args.preset.is_some();
     if let Some(preset_name) = &args.preset {
         if let Some(preset) = Preset::from_name(preset_name) {
             log::info!("Applying preset: {}", preset_name);
@@ -192,17 +201,41 @@ fn main() -> Result<()> {
         }
     }
 
-    // Apply individual settings (these override preset values)
-    processor = processor
-        .speed(args.speed)
-        .codec(&args.codec)
-        .quality(args.quality)
-        .profile(args.profile)
-        .contrast(args.contrast)
-        .saturation(args.saturation)
-        .hardware_accel(args.hw_accel)
-        .stabilize(args.stabilize)
-        .auto_rotate(!args.no_auto_rotate);
+    // Apply individual settings (these override preset values).
+    // When a preset is used, only apply a setting if the user passed the flag
+    // explicitly on the command line, so preset values are not clobbered by
+    // the clap default values.
+    let explicit =
+        |id: &str| matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine);
+    if !preset_used || explicit("speed") {
+        processor = processor.speed(args.speed);
+    }
+    if !preset_used || explicit("codec") {
+        processor = processor.codec(&args.codec);
+    }
+    if !preset_used || explicit("quality") {
+        processor = processor.quality(args.quality);
+    }
+    if !preset_used || explicit("profile") {
+        processor = processor.profile(args.profile);
+    }
+    if !preset_used || explicit("contrast") {
+        processor = processor.contrast(args.contrast);
+    }
+    if !preset_used || explicit("saturation") {
+        processor = processor.saturation(args.saturation);
+    }
+    // Boolean toggles are gated the same way, so a preset that turns them on
+    // (e.g. stabilization) is not silently reset by the flag defaults.
+    if !preset_used || explicit("hw_accel") {
+        processor = processor.hardware_accel(args.hw_accel);
+    }
+    if !preset_used || explicit("stabilize") {
+        processor = processor.stabilize(args.stabilize);
+    }
+    if !preset_used || explicit("no_auto_rotate") {
+        processor = processor.auto_rotate(!args.no_auto_rotate);
+    }
 
     // Apply optional settings
     if let Some(bitrate) = args.bitrate {
@@ -256,4 +289,89 @@ fn main() -> Result<()> {
     println!("📁 Output saved to: {:?}", output);
 
     Ok(())
+}
+
+/// Expand the given paths into an ordered list of input files. Directories are
+/// replaced by their video files sorted by name; regular paths are kept as-is.
+fn resolve_inputs(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for path in paths {
+        if path.is_dir() {
+            let mut dir_files: Vec<PathBuf> = std::fs::read_dir(path)
+                .with_context(|| format!("Failed to read directory: {}", path.display()))?
+                .filter_map(|entry| entry.ok().map(|e| e.path()))
+                .filter(|p| is_video_file(p))
+                .collect();
+            dir_files.sort();
+            if dir_files.is_empty() {
+                anyhow::bail!("No video files found in directory: {}", path.display());
+            }
+            log::info!(
+                "Found {} video file(s) in {}",
+                dir_files.len(),
+                path.display()
+            );
+            files.extend(dir_files);
+        } else {
+            files.push(path.clone());
+        }
+    }
+    Ok(files)
+}
+
+/// Whether a path looks like a video file based on its extension.
+fn is_video_file(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_lowercase())
+            .as_deref(),
+        Some("mp4" | "mov" | "m4v" | "mkv" | "avi" | "webm")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_video_file_matches_extensions_case_insensitively() {
+        for name in ["a.mp4", "a.MP4", "b.mov", "c.MKV", "d.webm"] {
+            assert!(is_video_file(Path::new(name)), "{name} should be a video");
+        }
+        for name in ["telemetry.srt", "proxy.LRF", "notes.txt", "noext"] {
+            assert!(
+                !is_video_file(Path::new(name)),
+                "{name} should not be a video"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_inputs_passes_through_explicit_files_in_order() -> Result<()> {
+        let inputs = vec![PathBuf::from("b.mp4"), PathBuf::from("a.mov")];
+        // Explicit (non-directory) paths are kept as given, in order.
+        assert_eq!(resolve_inputs(&inputs)?, inputs);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_inputs_expands_directory_sorted_video_only() -> Result<()> {
+        let dir = std::env::temp_dir().join(format!("speedy_resolve_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir)?;
+        for name in ["clip_b.mp4", "clip_a.mp4", "telemetry.srt", "proxy.LRF"] {
+            std::fs::write(dir.join(name), b"")?;
+        }
+
+        let resolved = resolve_inputs(std::slice::from_ref(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let names: Vec<String> = resolved?
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        // Non-video files excluded; videos returned sorted by name.
+        assert_eq!(names, vec!["clip_a.mp4", "clip_b.mp4"]);
+        Ok(())
+    }
 }

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -9,7 +9,7 @@ use std::thread;
 /// FFmpeg command builder with fluent interface
 #[derive(Debug, Clone)]
 pub struct FFmpegCommand {
-    input: PathBuf,
+    inputs: Vec<PathBuf>,
     output: PathBuf,
     video_filters: Vec<String>,
     audio_filters: Vec<String>,
@@ -23,12 +23,26 @@ pub struct FFmpegCommand {
     extra_args: Vec<String>,
     metadata_args: Vec<String>,
     hw_accel: Option<String>,
+    /// When set (with multiple inputs), each input is normalized to this
+    /// `(width, height, fps)` and concatenated via the concat filter so clips
+    /// of differing resolution/orientation can be stitched into one output.
+    concat_normalize: Option<(u32, u32, String)>,
+    /// Known total duration in seconds, used for progress because the concat
+    /// filter does not produce a single `Duration` line FFmpeg can report.
+    total_duration: Option<f64>,
 }
 
 impl FFmpegCommand {
     pub fn new(input: impl AsRef<Path>, output: impl AsRef<Path>) -> Self {
+        Self::new_multi(vec![input.as_ref().to_path_buf()], output)
+    }
+
+    /// Create a command with multiple inputs. When combined with
+    /// [`concat_normalize`](Self::concat_normalize) the inputs are stitched
+    /// together into a single output.
+    pub fn new_multi(inputs: Vec<PathBuf>, output: impl AsRef<Path>) -> Self {
         Self {
-            input: input.as_ref().to_path_buf(),
+            inputs,
             output: output.as_ref().to_path_buf(),
             video_filters: Vec::new(),
             audio_filters: Vec::new(),
@@ -42,7 +56,27 @@ impl FFmpegCommand {
             extra_args: Vec::new(),
             metadata_args: Vec::new(),
             hw_accel: None,
+            concat_normalize: None,
+            total_duration: None,
         }
+    }
+
+    /// Stitch multiple inputs into one output: each input is scaled (preserving
+    /// aspect, padded if needed), auto-rotated, set to `fps`, then concatenated.
+    /// Any configured video filters (e.g. a LUT) are applied once after the join.
+    ///
+    /// Note: the stitched output is currently video-only; audio tracks are not
+    /// concatenated.
+    pub fn concat_normalize(mut self, width: u32, height: u32, fps: &str) -> Self {
+        self.concat_normalize = Some((width, height, fps.to_string()));
+        self
+    }
+
+    /// Provide a known total duration (seconds) for progress reporting.
+    /// Needed for concat, where FFmpeg cannot report a single Duration line.
+    pub fn total_duration(mut self, seconds: f64) -> Self {
+        self.total_duration = Some(seconds);
+        self
     }
 
     /// Set video codec
@@ -293,6 +327,17 @@ impl FFmpegCommand {
         self
     }
 
+    /// Pixel format the filtered stream is normalized to before encoding.
+    /// ProRes needs 10-bit 4:2:2; web codecs (H.264/H.265/VP9/AV1) use 8-bit
+    /// 4:2:0. This is what converts the RGB output of filters like lut3d back to
+    /// something the encoder accepts.
+    fn output_pixel_format(&self) -> &'static str {
+        match self.video_codec.as_deref() {
+            Some(codec) if codec.contains("prores") => "yuv422p10le",
+            _ => "yuv420p",
+        }
+    }
+
     /// Build the FFmpeg command
     pub fn build(&self) -> Command {
         let mut cmd = Command::new("ffmpeg");
@@ -302,47 +347,91 @@ impl FFmpegCommand {
             cmd.arg("-y");
         }
 
-        // Hardware acceleration
+        // Hardware acceleration (applies to the inputs that follow)
         if let Some(ref hw) = self.hw_accel {
             cmd.args(["-hwaccel", hw]);
         }
 
-        // Input file (autorotate is enabled by default)
-        cmd.args(["-i", self.input.to_str().unwrap()]);
-
-        // Build filter complex if we have filters
-        let mut filter_complex = String::new();
-        let mut has_video_filters = false;
-        let mut has_audio_filters = false;
-
-        if !self.video_filters.is_empty() {
-            filter_complex.push_str(&format!("[0:v]{}[v]", self.video_filters.join(",")));
-            has_video_filters = true;
+        // Input files (autorotation is enabled by default for each).
+        // Pass the path as an OsStr so non-UTF-8 paths don't panic.
+        for input in &self.inputs {
+            cmd.arg("-i").arg(input);
         }
 
-        if !self.audio_filters.is_empty() {
-            if has_video_filters {
-                filter_complex.push_str("; ");
+        let video_chain = self.video_filters.join(",");
+        let out_fmt = self.output_pixel_format();
+
+        if let Some((w, h, ref fps)) = self.concat_normalize {
+            // Stitch mode: normalize every input to a common size/fps (scaling
+            // down to fit and padding to keep aspect), concatenate them, then
+            // apply the shared video filter chain (e.g. the LUT) once.
+            let n = self.inputs.len();
+            let mut graph = String::new();
+            for i in 0..n {
+                // setpts=PTS-STARTPTS rebases each segment to start at 0, which
+                // the concat filter requires; otherwise clips with non-zero
+                // start PTS (trimmed sources, MP4 edit lists) can produce gaps
+                // or non-monotonic-timestamp failures.
+                graph.push_str(&format!(
+                    "[{i}:v]scale={w}:{h}:force_original_aspect_ratio=decrease,\
+                     pad={w}:{h}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps={fps},\
+                     setpts=PTS-STARTPTS[v{i}];"
+                ));
             }
-            filter_complex.push_str(&format!("[0:a]{}[a]", self.audio_filters.join(",")));
-            has_audio_filters = true;
-        }
+            for i in 0..n {
+                graph.push_str(&format!("[v{i}]"));
+            }
+            graph.push_str(&format!("concat=n={n}:v=1[cat]"));
+            // Normalize to a codec-friendly pixel format: RGB-producing filters
+            // such as lut3d would otherwise leave the stream as gbrp (planar
+            // RGB), which many encoders/players cannot handle.
+            if video_chain.is_empty() {
+                graph.push_str(&format!(";[cat]format={out_fmt}[v]"));
+            } else {
+                graph.push_str(&format!(";[cat]{video_chain},format={out_fmt}[v]"));
+            }
 
-        if !filter_complex.is_empty() {
             cmd.arg("-filter_complex");
-            cmd.arg(&filter_complex);
+            cmd.arg(&graph);
+            // Stitched clips are treated as video-only (no synchronized audio).
+            cmd.args(["-map", "[v]"]);
+        } else {
+            // Single-input mode: apply video/audio filters to input 0.
+            let mut filter_complex = String::new();
+            let mut has_video_filters = false;
+            let mut has_audio_filters = false;
 
-            // Map the filtered outputs
-            if has_video_filters {
-                cmd.args(["-map", "[v]"]);
-            } else {
-                cmd.args(["-map", "0:v?"]);
+            if !self.video_filters.is_empty() {
+                // The trailing format guards against RGB-producing filters (e.g.
+                // lut3d) leaving the output as gbrp, which breaks many encoders.
+                filter_complex.push_str(&format!("[0:v]{video_chain},format={out_fmt}[v]"));
+                has_video_filters = true;
             }
 
-            if has_audio_filters {
-                cmd.args(["-map", "[a]"]);
-            } else {
-                cmd.args(["-map", "0:a?"]);
+            if !self.audio_filters.is_empty() {
+                if has_video_filters {
+                    filter_complex.push_str("; ");
+                }
+                filter_complex.push_str(&format!("[0:a]{}[a]", self.audio_filters.join(",")));
+                has_audio_filters = true;
+            }
+
+            if !filter_complex.is_empty() {
+                cmd.arg("-filter_complex");
+                cmd.arg(&filter_complex);
+
+                // Map the filtered outputs
+                if has_video_filters {
+                    cmd.args(["-map", "[v]"]);
+                } else {
+                    cmd.args(["-map", "0:v?"]);
+                }
+
+                if has_audio_filters {
+                    cmd.args(["-map", "[a]"]);
+                } else {
+                    cmd.args(["-map", "0:a?"]);
+                }
             }
         }
 
@@ -384,8 +473,8 @@ impl FFmpegCommand {
             cmd.arg(arg);
         }
 
-        // Output file
-        cmd.arg(self.output.to_str().unwrap());
+        // Output file (passed as an OsStr to support non-UTF-8 paths)
+        cmd.arg(&self.output);
 
         cmd
     }
@@ -414,13 +503,17 @@ impl FFmpegCommand {
 
         let (tx, rx) = mpsc::channel();
 
+        // Use the caller-provided duration when available (e.g. concat input,
+        // where FFmpeg cannot report a real Duration line).
+        let total_override = self.total_duration;
+
         // Spawn thread to read stderr and parse progress
         let reader_thread = thread::spawn(move || {
             let reader = BufReader::new(stderr);
             let duration_regex = Regex::new(r"Duration: (\d{2}):(\d{2}):(\d{2})\.(\d{2})").unwrap();
             let progress_regex = Regex::new(r"time=(\d{2}):(\d{2}):(\d{2})\.(\d{2})").unwrap();
 
-            let mut total_duration: Option<f64> = None;
+            let mut total_duration: Option<f64> = total_override;
             let mut all_output = String::new();
 
             for line in reader.lines().map_while(Result::ok) {
@@ -516,8 +609,8 @@ pub fn get_video_info(path: impl AsRef<Path>) -> Result<VideoInfo> {
             "json",
             "-show_format",
             "-show_streams",
-            path.as_ref().to_str().unwrap(),
         ])
+        .arg(path.as_ref())
         .output()
         .context("Failed to run ffprobe")?;
 
@@ -583,4 +676,114 @@ pub struct VideoInfo {
     pub fps: f64,
     pub rotation: i32,
     pub has_audio: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Collect the built command's arguments as owned strings for inspection.
+    fn args_of(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// Extract the value passed to `-filter_complex`, if any.
+    fn filter_complex(args: &[String]) -> Option<&String> {
+        let idx = args.iter().position(|a| a == "-filter_complex")?;
+        args.get(idx + 1)
+    }
+
+    fn has_pair(args: &[String], first: &str, second: &str) -> bool {
+        args.windows(2).any(|w| w[0] == first && w[1] == second)
+    }
+
+    #[test]
+    fn single_input_without_filters_has_no_filter_complex() {
+        let args = args_of(&FFmpegCommand::new("in.mp4", "out.mp4").build());
+        assert!(!args.iter().any(|a| a == "-filter_complex"));
+        assert!(has_pair(&args, "-i", "in.mp4"));
+    }
+
+    #[test]
+    fn single_input_with_lut_forces_yuv420p() -> Result<()> {
+        let args = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .lut3d("grade.cube")
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        // The LUT runs in RGB; the chain must end in yuv420p for compatibility.
+        assert_eq!(fc, "[0:v]lut3d=grade.cube,format=yuv420p[v]");
+        assert!(has_pair(&args, "-map", "[v]"));
+        Ok(())
+    }
+
+    #[test]
+    fn concat_normalize_builds_join_graph() -> Result<()> {
+        let inputs = vec![
+            PathBuf::from("a.mp4"),
+            PathBuf::from("b.mp4"),
+            PathBuf::from("c.mp4"),
+        ];
+        let args = args_of(
+            &FFmpegCommand::new_multi(inputs, "out.mp4")
+                .lut3d("grade.cube")
+                .concat_normalize(3840, 2160, "30")
+                .build(),
+        );
+
+        // One -i per input.
+        assert_eq!(args.iter().filter(|a| a.as_str() == "-i").count(), 3);
+
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        for i in 0..3 {
+            assert!(
+                fc.contains(&format!(
+                    "[{i}:v]scale=3840:2160:force_original_aspect_ratio=decrease"
+                )),
+                "missing normalize chain for input {i}: {fc}"
+            );
+        }
+        // Each segment must be rebased to start at PTS 0 for the concat filter.
+        assert!(fc.contains("setpts=PTS-STARTPTS[v0]"), "graph: {fc}");
+        assert!(fc.contains("concat=n=3:v=1[cat]"), "graph: {fc}");
+        assert!(
+            fc.contains("[cat]lut3d=grade.cube,format=yuv420p[v]"),
+            "graph: {fc}"
+        );
+        assert!(has_pair(&args, "-map", "[v]"));
+        Ok(())
+    }
+
+    #[test]
+    fn prores_codec_keeps_10bit_422_pixel_format() -> Result<()> {
+        // ProRes does not support yuv420p; forcing it would degrade or fail.
+        let args = args_of(
+            &FFmpegCommand::new("in.mov", "out.mov")
+                .video_codec("prores_ks")
+                .lut3d("grade.cube")
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert!(fc.ends_with("format=yuv422p10le[v]"), "fc: {fc}");
+        Ok(())
+    }
+
+    #[test]
+    fn concat_normalize_without_filters_still_outputs_yuv420p() -> Result<()> {
+        let inputs = vec![PathBuf::from("a.mp4"), PathBuf::from("b.mp4")];
+        let args = args_of(
+            &FFmpegCommand::new_multi(inputs, "out.mp4")
+                .concat_normalize(1920, 1080, "30")
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert!(
+            fc.contains("concat=n=2:v=1[cat];[cat]format=yuv420p[v]"),
+            "graph: {fc}"
+        );
+        Ok(())
+    }
 }

--- a/speedy-core/src/lib.rs
+++ b/speedy-core/src/lib.rs
@@ -20,7 +20,7 @@ pub use video_processor::VideoProcessor;
 
 use clap::ValueEnum;
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, ValueEnum, PartialEq)]
 pub enum ColorProfile {
     Standard,
     DLog,

--- a/speedy-core/src/presets.rs
+++ b/speedy-core/src/presets.rs
@@ -2,8 +2,8 @@ use crate::{ColorProfile, VideoProcessor};
 
 /// Preset configurations for common video processing workflows
 pub enum Preset {
-    /// DJI drone footage with D-Log profile
-    DjiDLog,
+    /// DJI Mavic 4 Pro footage with D-Log profile
+    Mavic4ProDLog,
     /// DJI drone footage with standard profile
     DjiStandard,
     /// GoPro action camera footage
@@ -36,8 +36,8 @@ impl Preset {
     /// Apply preset to a video processor
     pub fn apply(&self, processor: VideoProcessor) -> VideoProcessor {
         match self {
-            Preset::DjiDLog => {
-                // DJI D-Log footage processing with vibrance instead of saturation
+            Preset::Mavic4ProDLog => {
+                // DJI Mavic 4 Pro D-Log footage processing with vibrance instead of saturation
                 processor
                     .profile(ColorProfile::DLog)
                     .contrast(1.15)
@@ -181,7 +181,9 @@ impl Preset {
     /// Get preset from string name
     pub fn from_name(name: &str) -> Option<Self> {
         match name.to_lowercase().as_str() {
-            "dji-dlog" | "dji_dlog" => Some(Preset::DjiDLog),
+            "mavic4pro-dlog" | "mavic4pro_dlog" | "mavic-4-pro-dlog" | "mavic4-pro-dlog" => {
+                Some(Preset::Mavic4ProDLog)
+            }
             "dji" | "dji-standard" => Some(Preset::DjiStandard),
             "gopro" => Some(Preset::GoPro),
             "sony-slog" | "slog" => Some(Preset::SonySLog),
@@ -202,7 +204,7 @@ impl Preset {
     /// Get description of the preset
     pub fn description(&self) -> &str {
         match self {
-            Preset::DjiDLog => "DJI drone footage with D-Log color profile",
+            Preset::Mavic4ProDLog => "DJI Mavic 4 Pro footage with D-Log color profile",
             Preset::DjiStandard => "DJI drone footage with standard color profile",
             Preset::GoPro => "GoPro action camera footage",
             Preset::SonySLog => "Sony camera footage with S-Log profile",
@@ -222,7 +224,10 @@ impl Preset {
     /// List all available presets
     pub fn list_all() -> Vec<(&'static str, &'static str)> {
         vec![
-            ("dji-dlog", "DJI drone footage with D-Log color profile"),
+            (
+                "mavic4pro-dlog",
+                "DJI Mavic 4 Pro footage with D-Log color profile",
+            ),
             ("dji", "DJI drone footage with standard color profile"),
             ("gopro", "GoPro action camera footage"),
             ("sony-slog", "Sony camera footage with S-Log profile"),
@@ -237,5 +242,41 @@ impl Preset {
             ("cinematic", "Cinematic teal and orange look"),
             ("portrait", "Portrait mode with skin tone protection"),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_name_resolves_mavic4pro_dlog_aliases() {
+        for alias in [
+            "mavic4pro-dlog",
+            "mavic4pro_dlog",
+            "mavic-4-pro-dlog",
+            "MAVIC4PRO-DLOG",
+        ] {
+            assert!(
+                matches!(Preset::from_name(alias), Some(Preset::Mavic4ProDLog)),
+                "alias {alias} should resolve to Mavic4ProDLog"
+            );
+        }
+    }
+
+    #[test]
+    fn from_name_rejects_old_and_unknown_names() {
+        // The preset was renamed away from "dji-dlog".
+        assert!(Preset::from_name("dji-dlog").is_none());
+        assert!(Preset::from_name("not-a-preset").is_none());
+    }
+
+    #[test]
+    fn list_all_advertises_mavic4pro_dlog() {
+        assert!(
+            Preset::list_all()
+                .iter()
+                .any(|(name, _)| *name == "mavic4pro-dlog")
+        );
     }
 }

--- a/speedy-core/src/video_processor.rs
+++ b/speedy-core/src/video_processor.rs
@@ -8,7 +8,10 @@ use crate::{ColorProfile, FFmpegCommand, check_ffmpeg, get_video_info};
 type ColorBalanceValues = (f32, f32, f32, f32, f32, f32, f32, f32, f32);
 
 pub struct VideoProcessor {
-    input_path: PathBuf,
+    /// One or more input clips. When more than one is given they are stitched
+    /// together (in order) into a single output via the concat filter, with each
+    /// clip normalized to a common resolution first.
+    inputs: Vec<PathBuf>,
     output_path: PathBuf,
     speed_multiplier: f64,
     codec: String,
@@ -34,8 +37,14 @@ pub struct VideoProcessor {
 
 impl VideoProcessor {
     pub fn new(input: impl AsRef<Path>, output: impl AsRef<Path>) -> Self {
+        Self::new_multi(vec![input.as_ref().to_path_buf()], output)
+    }
+
+    /// Create a processor that stitches multiple input clips into one output.
+    /// The clips are concatenated in the order given.
+    pub fn new_multi(inputs: Vec<PathBuf>, output: impl AsRef<Path>) -> Self {
         Self {
-            input_path: input.as_ref().to_path_buf(),
+            inputs,
             output_path: output.as_ref().to_path_buf(),
             speed_multiplier: 1.0,
             codec: "libx264".to_string(),
@@ -188,48 +197,45 @@ impl VideoProcessor {
         self
     }
 
-    /// Get the appropriate LUT file for the color profile
+    /// Get the appropriate LUT file for the color profile, if one is available.
+    ///
+    /// A missing profile LUT is not fatal: the LUT assets are not shipped with
+    /// the repository (they are git-ignored), so we log a warning and skip the
+    /// color conversion rather than aborting, letting the other preset
+    /// adjustments still apply.
     fn get_profile_lut(&self) -> Option<PathBuf> {
-        match self.profile {
-            ColorProfile::DLog => {
-                // Check for built-in D-Log LUT
-                let lut_path = PathBuf::from("luts/dji_dlog_to_rec709.cube");
-                if lut_path.exists() {
-                    Some(lut_path)
-                } else {
-                    log::warn!("D-Log LUT not found at luts/dji_dlog_to_rec709.cube");
-                    None
-                }
-            }
-            ColorProfile::SLog => {
-                let lut_path = PathBuf::from("luts/sony_slog_to_rec709.cube");
-                if lut_path.exists() {
-                    Some(lut_path)
-                } else {
-                    None
-                }
-            }
-            ColorProfile::CLog => {
-                let lut_path = PathBuf::from("luts/canon_clog_to_rec709.cube");
-                if lut_path.exists() {
-                    Some(lut_path)
-                } else {
-                    None
-                }
-            }
-            _ => None,
+        let (path, label) = match self.profile {
+            ColorProfile::DLog => ("luts/mavic4_pro_dlog_to_rec709.cube", "D-Log"),
+            ColorProfile::SLog => ("luts/sony_slog_to_rec709.cube", "S-Log"),
+            ColorProfile::CLog => ("luts/canon_clog_to_rec709.cube", "C-Log"),
+            _ => return None,
+        };
+
+        let lut_path = PathBuf::from(path);
+        if lut_path.exists() {
+            Some(lut_path)
+        } else {
+            log::warn!("{label} LUT not found at {path}; skipping color conversion");
+            None
         }
     }
 
     /// Process the video using FFmpeg CLI
     pub fn process(&self) -> Result<()> {
+        // Guard the indexing below: library callers can construct an empty
+        // processor via `new_multi`, which the CLI never does.
+        if self.inputs.is_empty() {
+            anyhow::bail!("No input files provided");
+        }
+
         // Check FFmpeg availability
         let ffmpeg_version = check_ffmpeg()?;
         log::info!("Using FFmpeg version: {}", ffmpeg_version);
 
-        // Get video info
+        // Get video info from the first clip (all stitched clips are assumed to
+        // share the same format, as they come from the same camera/source).
         log::info!("Analyzing input video...");
-        let info = get_video_info(&self.input_path)?;
+        let info = get_video_info(&self.inputs[0])?;
         log::info!(
             "Video info: {}x{}, {:.2} fps, {:.2}s duration, rotation: {}°, audio: {}",
             info.width,
@@ -240,12 +246,61 @@ impl VideoProcessor {
             if info.has_audio { "yes" } else { "no" }
         );
 
-        // Build FFmpeg command
-        let mut cmd = FFmpegCommand::new(&self.input_path, &self.output_path)
-            .video_codec(&self.codec)
-            .quality(self.quality)
-            .overwrite()
-            .preserve_metadata();
+        // When multiple clips are given, probe every clip so we can pick a
+        // common output resolution and sum the durations (for the progress bar).
+        let stitching = self.inputs.len() > 1;
+        let stitch_plan = if stitching {
+            let infos = self
+                .inputs
+                .iter()
+                .map(get_video_info)
+                .collect::<Result<Vec<_>>>()?;
+            let total: f64 = infos.iter().map(|i| i.duration).sum();
+            // Target the smallest display size across clips so nothing is
+            // upscaled; clips of other sizes are scaled to fit and padded.
+            let (width, height) = infos
+                .iter()
+                .map(display_dimensions)
+                .reduce(|(aw, ah), (bw, bh)| (aw.min(bw), ah.min(bh)))
+                .unwrap_or((info.width, info.height));
+            log::info!(
+                "Stitching {} clips ({total:.2}s total) at {width}x{height} into {:?}",
+                self.inputs.len(),
+                self.output_path
+            );
+            // Stitching currently produces a video-only output; warn loudly so
+            // dropped audio is never a silent surprise.
+            if infos.iter().any(|i| i.has_audio) {
+                log::warn!(
+                    "Some input clips have audio, but stitched output is video-only; audio will be dropped"
+                );
+            }
+            Some((width, height, total))
+        } else {
+            None
+        };
+
+        // Build FFmpeg command. In stitch mode all inputs are passed together;
+        // otherwise just the single clip.
+        let mut cmd = if stitch_plan.is_some() {
+            FFmpegCommand::new_multi(self.inputs.clone(), &self.output_path)
+        } else {
+            FFmpegCommand::new(&self.inputs[0], &self.output_path)
+        }
+        .video_codec(&self.codec)
+        .quality(self.quality)
+        .overwrite()
+        .preserve_metadata();
+
+        if let Some((width, height, total)) = stitch_plan {
+            // Probe the first video stream's frame rate specifically, so a file
+            // whose first stream is audio/data does not feed a bogus fps into
+            // the concat graph.
+            let fps = probe_video_fps(&self.inputs[0], info.fps);
+            cmd = cmd
+                .concat_normalize(width, height, &fps)
+                .total_duration(total);
+        }
 
         // Set bitrate if specified
         if let Some(bitrate) = self.bitrate {
@@ -284,8 +339,9 @@ impl VideoProcessor {
             cmd = cmd.lut3d(lut);
         } else if let Some(profile_lut) = self.get_profile_lut() {
             log::info!(
-                "Applying {profile} profile LUT",
-                profile = self.profile.to_string()
+                "Applying {} profile LUT: {}",
+                self.profile.to_string(),
+                profile_lut.display()
             );
             cmd = cmd.lut3d(profile_lut);
         }
@@ -393,5 +449,96 @@ impl VideoProcessor {
         log::info!("Output saved to: {:?}", self.output_path);
 
         Ok(())
+    }
+}
+
+/// Probe the first *video* stream's frame rate as an ffmpeg-ready string (e.g.
+/// `"30000/1001"`). Falls back to the formatted `default` when the value is
+/// missing or degenerate (e.g. a non-video first stream reporting `0/0`).
+fn probe_video_fps(path: &Path, default: f64) -> String {
+    let probed = std::process::Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=r_frame_rate",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(path)
+        .output()
+        .ok()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string());
+
+    if let Some(rate) = probed
+        && let Some((num, den)) = rate.split_once('/')
+        && let (Ok(num), Ok(den)) = (num.parse::<f64>(), den.parse::<f64>())
+        && num > 0.0
+        && den > 0.0
+    {
+        return rate;
+    }
+
+    format!("{default:.5}")
+}
+
+/// Display dimensions of a clip, accounting for a 90°/270° rotation flag
+/// (cameras often store rotated footage with a rotation tag).
+fn display_dimensions(info: &crate::VideoInfo) -> (u32, u32) {
+    if info.rotation.abs() % 180 == 90 {
+        (info.height, info.width)
+    } else {
+        (info.width, info.height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::VideoInfo;
+
+    fn info(width: u32, height: u32, rotation: i32) -> VideoInfo {
+        VideoInfo {
+            duration: 0.0,
+            width,
+            height,
+            fps: 30.0,
+            rotation,
+            has_audio: false,
+        }
+    }
+
+    #[test]
+    fn display_dimensions_swap_on_quarter_turns_only() {
+        // Upright / half-turn: dimensions stay as stored.
+        assert_eq!(display_dimensions(&info(3840, 2160, 0)), (3840, 2160));
+        assert_eq!(display_dimensions(&info(3840, 2160, 180)), (3840, 2160));
+        // Quarter turns (camera stored the frame rotated): width/height swap.
+        assert_eq!(display_dimensions(&info(3384, 6016, -90)), (6016, 3384));
+        assert_eq!(display_dimensions(&info(3384, 6016, 90)), (6016, 3384));
+        assert_eq!(display_dimensions(&info(3384, 6016, 270)), (6016, 3384));
+    }
+
+    #[test]
+    fn missing_profile_lut_degrades_to_none() {
+        // LUT assets are git-ignored and not shipped, so a log profile whose
+        // LUT is absent must skip color conversion (None) rather than abort.
+        let lut = PathBuf::from("luts/mavic4_pro_dlog_to_rec709.cube");
+        if lut.exists() {
+            // Skip when a developer happens to have the LUT present locally.
+            return;
+        }
+        let processor = VideoProcessor::new("in.mp4", "out.mp4").profile(crate::ColorProfile::DLog);
+        assert_eq!(processor.get_profile_lut(), None);
+    }
+
+    #[test]
+    fn process_rejects_empty_inputs() {
+        // A library caller can build an empty processor; it must return an
+        // error rather than panicking on input indexing.
+        let result = VideoProcessor::new_multi(Vec::new(), "out.mp4").process();
+        assert!(result.is_err(), "empty inputs should error, not panic");
     }
 }


### PR DESCRIPTION
## Summary
Adds the ability to stitch multiple clips (or a whole directory) into a single
graded output, and includes the git pre-commit/pre-push quality hooks.

## Stitching + grading
- Accept multiple `-i` inputs or a directory (expanded to its video files,
  sorted by name; non-video files ignored).
- Clips of differing resolution/orientation are auto-rotated and normalized to
  a common frame (scaled to fit + padded) via the concat filter before joining,
  so mixed 4K/6K and portrait/landscape footage combines cleanly.
- Color grade (e.g. a D-Log LUT) is applied once over the joined timeline.
- Output is forced to `yuv420p` so RGB-producing filters such as `lut3d` don't
  leave the stream as `gbrp`, which many players/hardware decoders reject.

## Other changes
- Rename the D-Log preset to `mavic4pro-dlog`; treat a missing profile LUT as an
  error instead of silently skipping color conversion.
- Only override preset values when the matching CLI flag is set explicitly (via
  the clap value source) rather than comparing against defaults.
- Add unit tests (0 → 11): command generation, input expansion, rotation-aware
  sizing, and preset name resolution.
- README updated with stitching usage.

## Test plan
- [x] `cargo test` — 11 passing
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Verified end-to-end on real mixed 4K/6K D-Log footage (8 clips → one 4K H.265 file, correct orientation/color, `yuv420p`)
- [ ] CI green
- [ ] Codex bot review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stitch multiple video clips together with automatic normalization and scaling
  * New DJI Mavic 4 Pro D-Log color profile preset

* **Documentation**
  * Updated README with multi-clip stitching examples and development setup guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->