### PR TITLE
ci: drop Magic Nix Cache and fix exposed security advisory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,6 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-      
       - name: Build x86_64 Linux (musl - static)
         run: |
           nix build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,6 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-      
       # Only cache cargo registry (dependencies), not target directory
       # Target caching conflicts with nix environment and multiple build targets
       - name: Cache Cargo registry
@@ -61,9 +58,6 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-      
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -154,9 +148,6 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-      
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       
       - name: Install cargo-audit
         run: nix develop -c cargo install cargo-audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"


### PR DESCRIPTION
## Summary
1. Remove the `DeterminateSystems/magic-nix-cache-action` step from `rust.yml` (×3) and `release.yml` (×1).
2. Bump `bytes` 1.10.1 → 1.11.1 to clear RUSTSEC-2026-0007.

## Why
The Magic Nix Cache was failing the **Security Audit** job with `HTTP 418` / `rate limit exceeded` while serving from its local substituter — which meant `cargo audit` never actually ran. Removing it makes Nix fetch from `cache.nixos.org` reliably, and the audit then runs and correctly flags a **real** advisory:

```
RUSTSEC-2026-0007: bytes 1.10.1 — Integer overflow in BytesMut::reserve
Solution: Upgrade to >=1.11.1
```

So the "flake" was masking a genuine vulnerability; this PR fixes both.

## Unchanged
- `cachix/install-nix-action` (the Nix installer, not a cache)
- `actions/cache` for the Cargo registry

## Test plan
- [x] `cargo build` / `cargo test` pass locally
- [ ] CI green, Security Audit passes