### PR TITLE
fix(speed): resample to target fps so speed-ups drop frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,13 @@ speedy -i clip1.mp4 clip2.mp4 clip3.mp4 -o combined.mp4
 # Stitch every video in a folder (sorted by filename) and grade from D-Log
 speedy -i /path/to/DCIM/DJI_001 --preset mavic4pro-dlog -o combined.mp4
 
-# Stitch a folder of DJI D-Log clips into a 10× hyperlapse with the D-Log LUT.
-# The speed-up decimates frames back to the source fps, so the output is a
-# short, normal-frame-rate clip (not a ~300 fps file).
+# Stitch a folder of DJI D-Log clips into a 10× hyperlapse. The speed-up
+# decimates frames back to the source fps, so the output is a short,
+# normal-frame-rate clip (not a ~300 fps file). `--profile d-log` auto-applies
+# the bundled D-Log LUT when one is present under luts/ (and is skipped with a
+# warning otherwise); or grade with your own via `--lut /path/to/your.cube`.
 speedy -i /path/to/DCIM/DJI_001 \
-  --lut "luts/mavic4_pro_dlog_to_rec709.cube" \
-  --speed 10 --codec h265 -o combined_10x.mp4
+  --profile d-log --speed 10 --codec h265 -o combined_10x.mp4
 ```
 
 ### Advanced Color Grading

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ This project is a Rust workspace with two crates:
 
 ## Features
 
-- **Speed adjustment** — speed up or slow down footage. Audio is retimed with
-  pitch correction (`atempo`), automatically chaining filters for speeds beyond
-  the 0.5×–2.0× range. Speed changes on video-only clips skip the audio path.
+- **Speed adjustment** — speed up or slow down footage. The retimed stream is
+  resampled back to a sane frame rate (the source fps by default, or `--output-fps`),
+  so a speed-up drops frames into a shorter clip instead of inflating the frame
+  rate — a 10× speed-up of 30 fps footage stays 30 fps rather than becoming
+  ~300 fps with every source frame re-encoded. Audio is retimed with pitch
+  correction (`atempo`), automatically chaining filters for speeds beyond the
+  0.5×–2.0× range. Speed changes on video-only clips skip the audio path.
 - **Multi-clip stitching** — pass several inputs (or a directory) to concatenate
   them into one output, in order. Clips of differing resolution or orientation
   are normalized to a common frame (scaled to fit and padded), so mixed 4K/6K
@@ -130,6 +134,13 @@ speedy -i clip1.mp4 clip2.mp4 clip3.mp4 -o combined.mp4
 
 # Stitch every video in a folder (sorted by filename) and grade from D-Log
 speedy -i /path/to/DCIM/DJI_001 --preset mavic4pro-dlog -o combined.mp4
+
+# Stitch a folder of DJI D-Log clips into a 10× hyperlapse with the D-Log LUT.
+# The speed-up decimates frames back to the source fps, so the output is a
+# short, normal-frame-rate clip (not a ~300 fps file).
+speedy -i /path/to/DCIM/DJI_001 \
+  --lut "luts/mavic4_pro_dlog_to_rec709.cube" \
+  --speed 10 --codec h265 -o combined_10x.mp4
 ```
 
 ### Advanced Color Grading
@@ -170,6 +181,7 @@ speedy -i input.mp4 -o output.mp4 --codec h265 --quality 18 --hw-accel
 | `-o, --output <PATH>` | Output video file | — |
 | `--preset <NAME>` | Apply a preset (see below) | — |
 | `-s, --speed <X>` | Speed multiplier (e.g. `2.0`) | `1.0` |
+| `--output-fps <FPS>` | Output frame rate for speed changes (e.g. `30`, `30000/1001`) | source fps |
 | `-l, --lut <FILE>` | `.cube` LUT for color grading | — |
 | `-p, --profile <PROFILE>` | Source profile: `standard`, `d-log`, `s-log`, `c-log`, `v-log`, `f-log` | `standard` |
 | `-c, --contrast <V>` | Contrast (0.0–2.0) | `1.0` |

--- a/speedy-cli/src/main.rs
+++ b/speedy-cli/src/main.rs
@@ -28,6 +28,12 @@ struct Args {
     #[arg(short, long, default_value = "1.0")]
     speed: f64,
 
+    /// Output frame rate for speed changes (e.g. "30" or "30000/1001").
+    /// Defaults to the source frame rate, so a speed-up drops frames instead of
+    /// inflating the frame rate (a 10x speed-up of 30fps stays 30fps).
+    #[arg(long, value_name = "FPS")]
+    output_fps: Option<String>,
+
     /// LUT file path for color grading (supports .cube files)
     #[arg(short, long)]
     lut: Option<PathBuf>,
@@ -280,6 +286,10 @@ fn main() -> Result<()> {
 
     if let Some(scale) = args.scale {
         processor = processor.scale(&scale);
+    }
+
+    if let Some(output_fps) = args.output_fps {
+        processor = processor.output_fps(&output_fps);
     }
 
     // Process the video

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -139,13 +139,29 @@ impl FFmpegCommand {
         self
     }
 
-    /// Set video speed (affects both video and audio)
-    /// If has_audio is false, only video speed is adjusted
-    pub fn speed(mut self, multiplier: f64, has_audio: bool) -> Self {
+    /// Set video speed (affects both video and audio).
+    ///
+    /// `setpts` only rescales timestamps, so a speed-up on its own keeps every
+    /// source frame and inflates the frame rate (a 10x speed-up of 30fps would
+    /// emit a ~300fps file with all frames re-encoded). When `output_fps` is
+    /// given, a trailing `fps` filter resamples the retimed stream back to that
+    /// rate: a speed-up then drops frames (a shorter clip at a normal fps) and a
+    /// slow-down duplicates them. Pass `None` to keep the raw retimed stream.
+    ///
+    /// If `has_audio` is false, only video speed is adjusted.
+    pub fn speed(mut self, multiplier: f64, has_audio: bool, output_fps: Option<&str>) -> Self {
         if multiplier != 1.0 {
             // Video speed adjustment
             self.video_filters
                 .push(format!("setpts={:.4}*PTS", 1.0 / multiplier));
+
+            // Resample the retimed stream to a sane frame rate so the output fps
+            // does not scale with the speed multiplier. Placed right after
+            // setpts so any later per-frame filters (e.g. a LUT) only process
+            // the frames that survive decimation.
+            if let Some(fps) = output_fps {
+                self.video_filters.push(format!("fps={fps}"));
+            }
 
             // Audio speed adjustment (with pitch correction) - only if audio exists
             if has_audio {
@@ -768,6 +784,70 @@ mod tests {
         );
         let fc = filter_complex(&args).context("expected -filter_complex")?;
         assert!(fc.ends_with("format=yuv422p10le[v]"), "fc: {fc}");
+        Ok(())
+    }
+
+    #[test]
+    fn speed_up_with_output_fps_decimates_frames() -> Result<()> {
+        // A 10x speed-up must retime via setpts AND resample to the target fps;
+        // without the fps filter the output keeps every source frame at ~10x the
+        // frame rate instead of becoming a shorter clip.
+        let args = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .speed(10.0, false, Some("30"))
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert_eq!(fc, "[0:v]setpts=0.1000*PTS,fps=30,format=yuv420p[v]");
+        Ok(())
+    }
+
+    #[test]
+    fn speed_change_without_output_fps_keeps_raw_retimed_stream() -> Result<()> {
+        // Back-compat: with no target fps only setpts is applied (no decimation).
+        let args = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .speed(2.0, false, None)
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert_eq!(fc, "[0:v]setpts=0.5000*PTS,format=yuv420p[v]");
+        Ok(())
+    }
+
+    #[test]
+    fn speed_resample_runs_before_a_lut() -> Result<()> {
+        // The fps decimation must precede the LUT so the LUT only grades the
+        // frames that survive the speed-up.
+        let args = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .speed(10.0, false, Some("30"))
+                .lut3d("grade.cube")
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert_eq!(
+            fc,
+            "[0:v]setpts=0.1000*PTS,fps=30,lut3d=grade.cube,format=yuv420p[v]"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn speed_up_retimes_audio_independently_of_video_fps() -> Result<()> {
+        // Video gets setpts + fps; audio is pitch-corrected with chained atempo
+        // (4x = 2.0 * 2.0) and is unaffected by the video frame-rate target.
+        let args = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .speed(4.0, true, Some("30"))
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert!(
+            fc.contains("[0:v]setpts=0.2500*PTS,fps=30,format=yuv420p[v]"),
+            "fc: {fc}"
+        );
+        assert!(fc.contains("[0:a]atempo=2.0,atempo=2.0000[a]"), "fc: {fc}");
         Ok(())
     }
 

--- a/speedy-core/src/video_processor.rs
+++ b/speedy-core/src/video_processor.rs
@@ -33,6 +33,10 @@ pub struct VideoProcessor {
     hue_shift: Option<f32>,
     color_balance: Option<ColorBalanceValues>,
     selective_color: Option<String>,
+    /// Target output frame rate used when the speed is changed. `None` defaults
+    /// to the source frame rate, which makes a speed-up drop frames instead of
+    /// inflating the frame rate.
+    output_fps: Option<String>,
 }
 
 impl VideoProcessor {
@@ -66,11 +70,20 @@ impl VideoProcessor {
             hue_shift: None,
             color_balance: None,
             selective_color: None,
+            output_fps: None,
         }
     }
 
     pub fn speed(mut self, multiplier: f64) -> Self {
         self.speed_multiplier = multiplier;
+        self
+    }
+
+    /// Set the target output frame rate used when the speed is changed (e.g.
+    /// `"30"` or `"30000/1001"`). Defaults to the source frame rate, so a
+    /// speed-up drops frames rather than producing a higher-fps file.
+    pub fn output_fps(mut self, fps: &str) -> Self {
+        self.output_fps = Some(fps.to_string());
         self
     }
 
@@ -329,9 +342,25 @@ impl VideoProcessor {
             }
         }
 
-        // Apply speed adjustment
+        // Apply speed adjustment. Resample to a target frame rate (the source
+        // fps unless overridden) so a speed-up yields a shorter clip at a normal
+        // frame rate instead of re-encoding every source frame at a multiplied
+        // fps. A degenerate/unknown source fps falls back to no resampling.
         if self.speed_multiplier != 1.0 {
-            cmd = cmd.speed(self.speed_multiplier, info.has_audio);
+            let target_fps = match &self.output_fps {
+                Some(fps) => Some(fps.clone()),
+                None => {
+                    let probed = probe_video_fps(&self.inputs[0], info.fps);
+                    fps_string_value(&probed).map(|_| probed)
+                }
+            };
+            if let Some(ref fps) = target_fps {
+                log::info!(
+                    "Resampling to {fps} fps after a {speed}x speed change",
+                    speed = self.speed_multiplier
+                );
+            }
+            cmd = cmd.speed(self.speed_multiplier, info.has_audio, target_fps.as_deref());
         }
 
         // Apply LUT if specified or use profile LUT
@@ -484,6 +513,25 @@ fn probe_video_fps(path: &Path, default: f64) -> String {
     format!("{default:.5}")
 }
 
+/// Parse an ffmpeg frame-rate string (`"30000/1001"` or `"29.97"`) into a
+/// positive float, returning `None` when it is missing, malformed, or
+/// non-positive. Used to reject a degenerate source fps before feeding it to the
+/// `fps` filter (where `fps=0` would be invalid).
+fn fps_string_value(s: &str) -> Option<f64> {
+    if let Some((num, den)) = s.split_once('/') {
+        let num: f64 = num.trim().parse().ok()?;
+        let den: f64 = den.trim().parse().ok()?;
+        if num > 0.0 && den > 0.0 {
+            Some(num / den)
+        } else {
+            None
+        }
+    } else {
+        let value: f64 = s.trim().parse().ok()?;
+        (value > 0.0).then_some(value)
+    }
+}
+
 /// Display dimensions of a clip, accounting for a 90°/270° rotation flag
 /// (cameras often store rotated footage with a rotation tag).
 fn display_dimensions(info: &crate::VideoInfo) -> (u32, u32) {
@@ -532,6 +580,26 @@ mod tests {
         }
         let processor = VideoProcessor::new("in.mp4", "out.mp4").profile(crate::ColorProfile::DLog);
         assert_eq!(processor.get_profile_lut(), None);
+    }
+
+    #[test]
+    fn fps_string_value_parses_rational_and_decimal() {
+        assert_eq!(fps_string_value("30000/1001"), Some(30000.0 / 1001.0));
+        assert_eq!(fps_string_value("30"), Some(30.0));
+        assert_eq!(fps_string_value("60.0"), Some(60.0));
+        // Degenerate or malformed rates are rejected so they never reach `fps=`.
+        assert_eq!(fps_string_value("0/0"), None);
+        assert_eq!(fps_string_value("0"), None);
+        assert_eq!(fps_string_value("abc"), None);
+    }
+
+    #[test]
+    fn output_fps_builder_sets_target() {
+        let processor = VideoProcessor::new("in.mp4", "out.mp4").output_fps("60");
+        assert_eq!(processor.output_fps.as_deref(), Some("60"));
+        // Unset by default, so the source fps is used.
+        let default = VideoProcessor::new("in.mp4", "out.mp4");
+        assert_eq!(default.output_fps, None);
     }
 
     #[test]

--- a/speedy-core/src/video_processor.rs
+++ b/speedy-core/src/video_processor.rs
@@ -348,9 +348,21 @@ impl VideoProcessor {
         // fps. A degenerate/unknown source fps falls back to no resampling.
         if self.speed_multiplier != 1.0 {
             let target_fps = match &self.output_fps {
-                Some(fps) => Some(fps.clone()),
+                Some(fps) => {
+                    // Validate an explicit override up front so a bad value
+                    // (e.g. `--output-fps 0` or `0/0`) fails fast with a clear
+                    // message instead of as a late, cryptic ffmpeg error.
+                    if fps_string_value(fps).is_none() {
+                        anyhow::bail!(
+                            "Invalid --output-fps {fps:?}; expected a positive number like \"30\" or \"30000/1001\""
+                        );
+                    }
+                    Some(fps.clone())
+                }
                 None => {
-                    let probed = probe_video_fps(&self.inputs[0], info.fps);
+                    // Default to the source's average cadence, which is the
+                    // correct decimation target for variable-frame-rate inputs.
+                    let probed = probe_target_fps(&self.inputs[0], info.fps);
                     fps_string_value(&probed).map(|_| probed)
                 }
             };
@@ -481,36 +493,56 @@ impl VideoProcessor {
     }
 }
 
-/// Probe the first *video* stream's frame rate as an ffmpeg-ready string (e.g.
-/// `"30000/1001"`). Falls back to the formatted `default` when the value is
-/// missing or degenerate (e.g. a non-video first stream reporting `0/0`).
+/// Probe the first *video* stream's base frame rate (`r_frame_rate`) as an
+/// ffmpeg-ready string (e.g. `"30000/1001"`). Falls back to the formatted
+/// `default` when the value is missing or degenerate (e.g. a non-video first
+/// stream reporting `0/0`). Used to set a common CFR cadence when stitching.
 fn probe_video_fps(path: &Path, default: f64) -> String {
-    let probed = std::process::Command::new("ffprobe")
+    probe_stream_rate(path, "r_frame_rate").unwrap_or_else(|| format!("{default:.5}"))
+}
+
+/// Probe the decimation target for a speed change: the first video stream's
+/// average cadence (`avg_frame_rate`), falling back to the base `r_frame_rate`
+/// and then the formatted `default`. The average rate is the right target for
+/// variable-frame-rate sources — there `r_frame_rate` is only a timebase guess
+/// and can be far higher than the real cadence, which would otherwise keep too
+/// many frames after a speed-up.
+fn probe_target_fps(path: &Path, default: f64) -> String {
+    probe_stream_rate(path, "avg_frame_rate")
+        .or_else(|| probe_stream_rate(path, "r_frame_rate"))
+        .unwrap_or_else(|| format!("{default:.5}"))
+}
+
+/// Read a single rational rate entry (`r_frame_rate` or `avg_frame_rate`) for
+/// the first video stream, returning it verbatim only when it is a positive
+/// rational (`num > 0 && den > 0`); otherwise `None`.
+fn probe_stream_rate(path: &Path, entry: &str) -> Option<String> {
+    let show_entries = format!("stream={entry}");
+    let rate = std::process::Command::new("ffprobe")
         .args([
             "-v",
             "error",
             "-select_streams",
             "v:0",
             "-show_entries",
-            "stream=r_frame_rate",
+            show_entries.as_str(),
             "-of",
             "default=noprint_wrappers=1:nokey=1",
         ])
         .arg(path)
         .output()
         .ok()
-        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string());
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())?;
 
-    if let Some(rate) = probed
-        && let Some((num, den)) = rate.split_once('/')
+    if let Some((num, den)) = rate.split_once('/')
         && let (Ok(num), Ok(den)) = (num.parse::<f64>(), den.parse::<f64>())
         && num > 0.0
         && den > 0.0
     {
-        return rate;
+        Some(rate)
+    } else {
+        None
     }
-
-    format!("{default:.5}")
 }
 
 /// Parse an ffmpeg frame-rate string (`"30000/1001"` or `"29.97"`) into a


### PR DESCRIPTION
## Summary
Speed changes only applied `setpts`, which rescales timestamps without dropping frames. A 10x speed-up of 30fps footage produced a ~300fps file with every source frame re-encoded, instead of a shorter clip at a normal frame rate — making large speed-ups impractical (e.g. stitching DJI D-Log clips into a 10x hyperlapse).

## Changes
- `FFmpegCommand::speed` takes an `output_fps: Option<&str>` and appends an `fps=` filter right after `setpts` (before any LUT, so per-frame filters only process surviving frames). `None` preserves the previous raw-retime behavior.
- `VideoProcessor` gains an `output_fps` field/builder; `process()` defaults the target to the source fps (via `probe_video_fps`), guarded by a new `fps_string_value` parser so a degenerate `0`/`0/0` rate never reaches `fps=`.
- New `--output-fps <FPS>` CLI flag (defaults to source fps).
- README: documented the speed/frame-rate behavior, the new option, and a DJI 10x hyperlapse example.

## Test Plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --locked --offline --workspace --all-targets -- --deny warnings` clean
- [x] `cargo test` — 20 passed; new tests cover the decimation chain, back-compat (`None`), ordering before a LUT, audio retiming independence, and fps parsing
- [x] End-to-end: 16.2s 4K clip at `--speed 10` now yields a 29.97fps, 1.635s output (filter `setpts=0.1000*PTS,fps=30000/1001,lut3d=...`), where the old behavior emitted ~300fps

## Breaking Changes
- `FFmpegCommand::speed` now takes a third argument `output_fps: Option<&str>`. Library callers should pass `None` to keep the prior behavior, or `Some(fps)` to resample. (`VideoProcessor`/CLI users are unaffected; the default is the source fps.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional output frame rate setting for speed changes, letting clips keep a chosen frame rate instead of always stretching it.
  * Improved speed adjustment behavior for video-only clips and longer speed ranges.

* **Bug Fixes**
  * Audio now stays in sync better during speed changes, with pitch correction preserved.
  * Frame-rate handling is more consistent when applying speed adjustments and effects together.

* **Documentation**
  * Expanded the speed adjustment docs with clearer examples and a new option reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->