### PR TITLE
feat(color): add --dehaze for atmospheric haze removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ This project is a Rust workspace with two crates:
 - **Color enhancement filters**:
   - Contrast and saturation
   - Vibrance (intelligent saturation that protects skin tones)
+  - Dehaze (`--dehaze`) — removes atmospheric haze by pulling the black point,
+    adding contrast, and restoring saturation/vibrance (a DaVinci-style "dehaze"
+    approximated with `curves`/`eq`/`vibrance`)
   - Color curves (presets or custom curve definitions)
   - Color balance across shadows, midtones, and highlights
   - Selective color adjustments
@@ -150,6 +153,9 @@ speedy -i /path/to/DCIM/DJI_001 \
 # Vibrance plus a lighter curve
 speedy -i input.mp4 -o output.mp4 --vibrance 0.5 --curves "preset=lighter"
 
+# Remove atmospheric haze from flat/weather-affected footage (0.5 = medium)
+speedy -i hazy.mp4 -o clear.mp4 --dehaze 0.5
+
 # Cinematic teal and orange look
 speedy -i input.mp4 -o output.mp4 --preset cinematic
 
@@ -197,6 +203,7 @@ speedy -i input.mp4 -o output.mp4 --codec h265 --quality 18 --hw-accel
 | `--denoise <1-10>` | Denoising strength | — |
 | `--sharpen <0.1-2.0>` | Sharpening strength | — |
 | `--vibrance <-2.0..2.0>` | Vibrance (protects skin tones) | — |
+| `--dehaze <STRENGTH>` | Remove atmospheric haze (~`0.5` medium, `1.0` strong) | — |
 | `--curves <SPEC>` | Color curves, e.g. `preset=lighter` | — |
 | `--hue-shift <-180..180>` | Hue shift in degrees | — |
 | `--color-balance <SPEC>` | `shadows,midtones,highlights` as `r:g:b` | — |

--- a/speedy-cli/src/main.rs
+++ b/speedy-cli/src/main.rs
@@ -90,6 +90,11 @@ struct Args {
     #[arg(long)]
     vibrance: Option<f32>,
 
+    /// Remove atmospheric haze at the given strength (~0.5 medium, 1.0 strong).
+    /// Pulls the black point, adds contrast, and restores saturation/vibrance.
+    #[arg(long, value_name = "STRENGTH")]
+    dehaze: Option<f32>,
+
     /// Apply color curves (e.g., "preset=lighter" or "red='0/0 0.5/0.6 1/1'")
     #[arg(long)]
     curves: Option<String>,
@@ -266,6 +271,10 @@ fn main() -> Result<()> {
 
     if let Some(vibrance) = args.vibrance {
         processor = processor.vibrance(vibrance);
+    }
+
+    if let Some(dehaze) = args.dehaze {
+        processor = processor.dehaze(dehaze);
     }
 
     if let Some(curves) = args.curves {

--- a/speedy-cli/src/main.rs
+++ b/speedy-cli/src/main.rs
@@ -90,8 +90,9 @@ struct Args {
     #[arg(long)]
     vibrance: Option<f32>,
 
-    /// Remove atmospheric haze at the given strength (~0.5 medium, 1.0 strong).
-    /// Pulls the black point, adds contrast, and restores saturation/vibrance.
+    /// Remove atmospheric haze at the given strength (~0.5 medium, 1.0 strong;
+    /// clamped to 0.0-1.0). Pulls the black point, adds contrast, and restores
+    /// saturation/vibrance.
     #[arg(long, value_name = "STRENGTH")]
     dehaze: Option<f32>,
 

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -286,6 +286,32 @@ impl FFmpegCommand {
         self
     }
 
+    /// Apply a haze-removal grade ("dehaze") of the given strength.
+    ///
+    /// Atmospheric haze lifts the black point and washes out contrast and
+    /// colour. There is no native ffmpeg dehaze filter, so this approximates one
+    /// (DaVinci-style): pull the black point down with `curves` to remove the
+    /// veil, add contrast/saturation with `eq` (nudging gamma up so the lifted
+    /// blacks don't crush the midtones), then restore colour with `vibrance`.
+    /// All amounts scale with `strength`, where ~0.5 is a balanced "medium" and
+    /// 1.0 is strong; values are clamped to be non-negative.
+    pub fn dehaze(mut self, strength: f32) -> Self {
+        let s = strength.max(0.0);
+        let black_point = 0.10 * s;
+        let contrast = 1.0 + 0.15 * s;
+        let saturation = 1.0 + 0.35 * s;
+        let gamma = 1.0 + 0.06 * s;
+        let vibrance = 0.9 * s;
+        self.video_filters
+            .push(format!("curves=all='{black_point:.3}/0 1/1'"));
+        self.video_filters.push(format!(
+            "eq=contrast={contrast:.3}:saturation={saturation:.3}:gamma={gamma:.3}"
+        ));
+        self.video_filters
+            .push(format!("vibrance=intensity={vibrance:.3}"));
+        self
+    }
+
     /// Apply color curves
     pub fn curves(mut self, curves_str: &str) -> Self {
         // Curves can be preset names or custom curve definitions
@@ -848,6 +874,38 @@ mod tests {
             "fc: {fc}"
         );
         assert!(fc.contains("[0:a]atempo=2.0,atempo=2.0000[a]"), "fc: {fc}");
+        Ok(())
+    }
+
+    #[test]
+    fn dehaze_builds_blackpoint_contrast_vibrance_chain() -> Result<()> {
+        // strength 0.5 -> black 0.05, contrast 1.075, sat 1.175, gamma 1.030,
+        // vibrance 0.45. The black-point curve must come first (veil removal),
+        // then eq, then vibrance.
+        let args = args_of(&FFmpegCommand::new("in.mp4", "out.mp4").dehaze(0.5).build());
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert_eq!(
+            fc,
+            "[0:v]curves=all='0.050/0 1/1',eq=contrast=1.075:saturation=1.175:gamma=1.030,vibrance=intensity=0.450,format=yuv420p[v]"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn dehaze_runs_after_a_lut() -> Result<()> {
+        // Dehaze grades the Rec.709 image, so it must follow the LUT.
+        let args = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .lut3d("grade.cube")
+                .dehaze(1.0)
+                .build(),
+        );
+        let fc = filter_complex(&args).context("expected -filter_complex")?;
+        assert!(
+            fc.starts_with("[0:v]lut3d=grade.cube,curves=all="),
+            "fc: {fc}"
+        );
+        assert!(fc.ends_with("format=yuv420p[v]"), "fc: {fc}");
         Ok(())
     }
 

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -294,9 +294,12 @@ impl FFmpegCommand {
     /// veil, add contrast/saturation with `eq` (nudging gamma up so the lifted
     /// blacks don't crush the midtones), then restore colour with `vibrance`.
     /// All amounts scale with `strength`, where ~0.5 is a balanced "medium" and
-    /// 1.0 is strong; values are clamped to be non-negative.
+    /// 1.0 is strong. The strength is clamped to `[0.0, 1.0]`: beyond 1.0 the
+    /// derived values would leave their valid ranges (e.g. a black point >= 1.0
+    /// makes a non-increasing `curves` point, or vibrance exceeds +/-2), which
+    /// FFmpeg rejects.
     pub fn dehaze(mut self, strength: f32) -> Self {
-        let s = strength.max(0.0);
+        let s = strength.clamp(0.0, 1.0);
         let black_point = 0.10 * s;
         let contrast = 1.0 + 0.15 * s;
         let saturation = 1.0 + 0.35 * s;
@@ -888,6 +891,26 @@ mod tests {
             fc,
             "[0:v]curves=all='0.050/0 1/1',eq=contrast=1.075:saturation=1.175:gamma=1.030,vibrance=intensity=0.450,format=yuv420p[v]"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn dehaze_clamps_strength_to_valid_range() -> Result<()> {
+        // Strengths above 1.0 are clamped: otherwise the black point reaches/
+        // exceeds 1.0 (a non-increasing curves point) and vibrance/saturation
+        // leave their valid ranges, which FFmpeg rejects.
+        let at_max = filter_complex(&args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4").dehaze(1.0).build(),
+        ))
+        .context("expected -filter_complex")?
+        .clone();
+        let over_max = filter_complex(&args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4").dehaze(10.0).build(),
+        ))
+        .context("expected -filter_complex")?
+        .clone();
+        assert_eq!(at_max, over_max);
+        assert!(at_max.contains("curves=all='0.100/0 1/1'"), "fc: {at_max}");
         Ok(())
     }
 

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -299,7 +299,13 @@ impl FFmpegCommand {
     /// makes a non-increasing `curves` point, or vibrance exceeds +/-2), which
     /// FFmpeg rejects.
     pub fn dehaze(mut self, strength: f32) -> Self {
-        let s = strength.clamp(0.0, 1.0);
+        // `clamp` keeps NaN as NaN (and would emit "NaN" into the filtergraph),
+        // so map NaN to 0.0 (no-op) first; clamp then bounds +/-inf to [0, 1].
+        let s = if strength.is_nan() {
+            0.0
+        } else {
+            strength.clamp(0.0, 1.0)
+        };
         let black_point = 0.10 * s;
         let contrast = 1.0 + 0.15 * s;
         let saturation = 1.0 + 0.35 * s;
@@ -911,6 +917,27 @@ mod tests {
         .clone();
         assert_eq!(at_max, over_max);
         assert!(at_max.contains("curves=all='0.100/0 1/1'"), "fc: {at_max}");
+        Ok(())
+    }
+
+    #[test]
+    fn dehaze_treats_nan_as_zero() -> Result<()> {
+        // `f32::clamp` preserves NaN, which would emit "NaN" into the filter
+        // graph; NaN must degrade to a no-op (strength 0) instead.
+        let nan = filter_complex(&args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .dehaze(f32::NAN)
+                .build(),
+        ))
+        .context("expected -filter_complex")?
+        .clone();
+        let zero = filter_complex(&args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4").dehaze(0.0).build(),
+        ))
+        .context("expected -filter_complex")?
+        .clone();
+        assert_eq!(nan, zero);
+        assert!(!nan.contains("NaN"), "fc must not contain NaN: {nan}");
         Ok(())
     }
 

--- a/speedy-core/src/video_processor.rs
+++ b/speedy-core/src/video_processor.rs
@@ -37,6 +37,8 @@ pub struct VideoProcessor {
     /// to the source frame rate, which makes a speed-up drop frames instead of
     /// inflating the frame rate.
     output_fps: Option<String>,
+    /// Haze-removal strength (~0.5 medium, 1.0 strong). `None` disables it.
+    dehaze: Option<f32>,
 }
 
 impl VideoProcessor {
@@ -71,6 +73,7 @@ impl VideoProcessor {
             color_balance: None,
             selective_color: None,
             output_fps: None,
+            dehaze: None,
         }
     }
 
@@ -84,6 +87,13 @@ impl VideoProcessor {
     /// speed-up drops frames rather than producing a higher-fps file.
     pub fn output_fps(mut self, fps: &str) -> Self {
         self.output_fps = Some(fps.to_string());
+        self
+    }
+
+    /// Enable haze removal at the given strength (~0.5 medium, 1.0 strong).
+    /// Pulls the black point, adds contrast, and restores saturation/vibrance.
+    pub fn dehaze(mut self, strength: f32) -> Self {
+        self.dehaze = Some(strength);
         self
     }
 
@@ -387,6 +397,14 @@ impl VideoProcessor {
             cmd = cmd.lut3d(profile_lut);
         }
 
+        // Apply haze removal (after the LUT, so it grades the Rec.709 image).
+        if let Some(strength) = self.dehaze
+            && strength > 0.0
+        {
+            log::info!("Applying dehaze (strength {strength})");
+            cmd = cmd.dehaze(strength);
+        }
+
         // Apply color adjustments
         if self.contrast != 1.0 || self.saturation != 1.0 {
             cmd = cmd.color_enhance(self.contrast, self.saturation);
@@ -623,6 +641,14 @@ mod tests {
         assert_eq!(fps_string_value("0/0"), None);
         assert_eq!(fps_string_value("0"), None);
         assert_eq!(fps_string_value("abc"), None);
+    }
+
+    #[test]
+    fn dehaze_builder_sets_strength() {
+        let processor = VideoProcessor::new("in.mp4", "out.mp4").dehaze(0.5);
+        assert_eq!(processor.dehaze, Some(0.5));
+        // Off by default.
+        assert_eq!(VideoProcessor::new("in.mp4", "out.mp4").dehaze, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Flat, weather/haze-affected footage reads as low contrast with washed-out colour — and vibrance alone doesn't fix it, because the real problem is the atmospheric veil (lifted black point + compressed contrast). This adds a `--dehaze` grade that approximates DaVinci Resolve's dehaze using native ffmpeg filters.

## Approach
There is no native ffmpeg dehaze filter, so `--dehaze <strength>` composes three stages (applied after any LUT, so it grades the Rec.709 image):
1. `curves=all='<bp>/0 1/1'` — pull the black point down to remove the haze veil
2. `eq=contrast=…:saturation=…:gamma=…` — restore contrast (gamma nudged up so lifted blacks don't crush midtones)
3. `vibrance=intensity=…` — bring colour back

All amounts scale with a single strength (clamped ≥ 0): `~0.5` is a balanced medium, `1.0` is strong. Example: `--dehaze 0.5` →
`curves=all='0.050/0 1/1',eq=contrast=1.075:saturation=1.175:gamma=1.030,vibrance=intensity=0.450`.

## Changes
- `FFmpegCommand::dehaze(strength)` builds the curves/eq/vibrance chain.
- `VideoProcessor` gains a `dehaze` field/builder; `process()` applies it after the LUT (skipped when strength ≤ 0).
- New `--dehaze <STRENGTH>` CLI flag.
- README: feature bullet, options-table row, and an example.

## Test Plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --locked --offline --workspace --all-targets -- --deny warnings` clean
- [x] `cargo test` — 23 passed (new: dehaze filter chain, ordering after a LUT, builder)
- [x] End-to-end: `speedy --dehaze 0.5` on real DJI footage produces the expected filtergraph and output; visually removes haze and restores depth/colour on both golden-hour and daytime aerial scenes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--dehaze <STRENGTH>` CLI option to reduce atmospheric haze during video processing, including updates to the command reference and examples.
* **Bug Fixes**
  * Dehaze is now applied only when enabled and in the correct visual order alongside LUT/color grading.
  * Strength is handled safely by clamping and ignoring non-positive values.
* **Tests**
  * Added coverage for dehaze output, clamping behavior, and filter ordering (including interactions with LUTs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->