### PR TITLE
fix: harden ffmpeg handling from codex review (paths, speed, rotation, containers)

### DIFF
--- a/speedy-cli/src/main.rs
+++ b/speedy-cli/src/main.rs
@@ -187,8 +187,9 @@ fn main() -> Result<()> {
         .output
         .ok_or_else(|| anyhow::anyhow!("Output file required"))?;
 
-    // Create output directory if it doesn't exist
-    if let Some(parent) = output.parent() {
+    // Create output directory if it doesn't exist. Skip an empty parent (a bare
+    // filename like `out.mp4`), where create_dir_all("") would error.
+    if let Some(parent) = output.parent().filter(|p| !p.as_os_str().is_empty()) {
         std::fs::create_dir_all(parent).context("Failed to create output directory")?;
     }
 

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -37,6 +37,9 @@ pub struct FFmpegCommand {
     /// reference files by name (avoiding filtergraph path-escaping pitfalls with
     /// colons/backslashes in absolute paths).
     working_dir: Option<PathBuf>,
+    /// When set, disable ffmpeg's automatic rotation (`-noautorotate`) on every
+    /// input, so footage keeps its stored orientation.
+    no_autorotate: bool,
 }
 
 impl FFmpegCommand {
@@ -67,6 +70,7 @@ impl FFmpegCommand {
             total_duration: None,
             video_only: false,
             working_dir: None,
+            no_autorotate: false,
         }
     }
 
@@ -98,6 +102,13 @@ impl FFmpegCommand {
     /// reference files by name and avoid filtergraph path-escaping issues.
     pub fn current_dir(mut self, dir: impl AsRef<Path>) -> Self {
         self.working_dir = Some(dir.as_ref().to_path_buf());
+        self
+    }
+
+    /// Disable ffmpeg's automatic rotation on every input (`-noautorotate`), so
+    /// the stored orientation is kept as-is.
+    pub fn disable_autorotate(mut self) -> Self {
+        self.no_autorotate = true;
         self
     }
 
@@ -399,12 +410,15 @@ impl FFmpegCommand {
         self
     }
 
-    /// Preserve metadata
+    /// Preserve metadata. `-movflags use_metadata_tags` is MP4/MOV-specific, so
+    /// it's only added for those containers (it errors/warns on MKV/WebM/etc.).
     pub fn preserve_metadata(mut self) -> Self {
         self.metadata_args.push("-map_metadata".to_string());
         self.metadata_args.push("0".to_string());
-        self.metadata_args.push("-movflags".to_string());
-        self.metadata_args.push("use_metadata_tags".to_string());
+        if is_mp4_family(&self.output) {
+            self.metadata_args.push("-movflags".to_string());
+            self.metadata_args.push("use_metadata_tags".to_string());
+        }
         self
     }
 
@@ -444,9 +458,13 @@ impl FFmpegCommand {
             cmd.args(["-hwaccel", hw]);
         }
 
-        // Input files (autorotation is enabled by default for each).
+        // Input files. Autorotation is on by default per input; `-noautorotate`
+        // (an input option, so it precedes each `-i`) disables it.
         // Pass the path as an OsStr so non-UTF-8 paths don't panic.
         for input in &self.inputs {
+            if self.no_autorotate {
+                cmd.arg("-noautorotate");
+            }
             cmd.arg("-i").arg(input);
         }
 
@@ -583,7 +601,10 @@ impl FFmpegCommand {
         F: Fn(f64, String) + Send + 'static,
     {
         let mut cmd = self.build();
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        // Progress is parsed from stderr; stdout is unused. Discard it rather
+        // than pipe-without-draining, which could deadlock if ffmpeg writes a
+        // lot to stdout (e.g. a stream muxed to "-").
+        cmd.stdout(Stdio::null()).stderr(Stdio::piped());
 
         log::info!("Executing FFmpeg command: {:?}", cmd);
 
@@ -679,6 +700,19 @@ impl FFmpegCommand {
     }
 }
 
+/// Whether `path`'s extension is an MP4/MOV-family container, where `-movflags`
+/// (`use_metadata_tags`, `+faststart`) applies. Other containers (MKV, WebM)
+/// reject those flags.
+pub fn is_mp4_family(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .as_deref(),
+        Some("mp4" | "mov" | "m4v")
+    )
+}
+
 /// Check if FFmpeg is available and return version info
 pub fn check_ffmpeg() -> Result<String> {
     let output = Command::new("ffmpeg")
@@ -711,6 +745,21 @@ pub fn get_video_info(path: impl AsRef<Path>) -> Result<VideoInfo> {
         .arg(path.as_ref())
         .output()
         .context("Failed to run ffprobe")?;
+
+    // ffprobe failed (missing/corrupt file, etc.): don't silently return zeroed
+    // metadata, which would feed a bogus 0x0 / 0fps plan into the pipeline.
+    if !output.status.success() {
+        anyhow::bail!(
+            "ffprobe failed for {path} (exit {code}): {stderr}",
+            path = path.as_ref().display(),
+            code = output
+                .status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string()),
+            stderr = String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
 
     let json = String::from_utf8_lossy(&output.stdout);
 
@@ -1041,6 +1090,59 @@ mod tests {
             "fc: {fc}"
         );
         Ok(())
+    }
+
+    #[test]
+    fn disable_autorotate_emits_noautorotate_before_each_input() {
+        let args = args_of(
+            &FFmpegCommand::new_multi(
+                vec![PathBuf::from("a.mp4"), PathBuf::from("b.mp4")],
+                "out.mp4",
+            )
+            .disable_autorotate()
+            .build(),
+        );
+        // -noautorotate is an input option, so it must immediately precede each -i.
+        let i_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.as_str() == "-i")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(i_positions.len(), 2, "args: {args:?}");
+        for p in i_positions {
+            assert!(p > 0 && args[p - 1] == "-noautorotate", "args: {args:?}");
+        }
+    }
+
+    #[test]
+    fn preserve_metadata_movflags_only_for_mp4_family() {
+        let mp4 = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mp4")
+                .preserve_metadata()
+                .build(),
+        );
+        assert!(has_pair(&mp4, "-movflags", "use_metadata_tags"), "{mp4:?}");
+        let mkv = args_of(
+            &FFmpegCommand::new("in.mp4", "out.mkv")
+                .preserve_metadata()
+                .build(),
+        );
+        assert!(
+            !mkv.iter().any(|a| a == "-movflags"),
+            "mkv must not get -movflags: {mkv:?}"
+        );
+        assert!(has_pair(&mkv, "-map_metadata", "0"), "{mkv:?}");
+    }
+
+    #[test]
+    fn is_mp4_family_matches_mp4_mov_m4v_only() {
+        for ok in ["a.mp4", "a.MOV", "clip.m4v"] {
+            assert!(is_mp4_family(Path::new(ok)), "{ok}");
+        }
+        for no in ["a.mkv", "a.webm", "a.avi", "noext"] {
+            assert!(!is_mp4_family(Path::new(no)), "{no}");
+        }
     }
 
     #[test]

--- a/speedy-core/src/ffmpeg_wrapper.rs
+++ b/speedy-core/src/ffmpeg_wrapper.rs
@@ -260,11 +260,14 @@ impl FFmpegCommand {
         self
     }
 
-    /// Apply 3D LUT
+    /// Apply a 3D LUT. The path is single-quoted (with embedded `'` escaped as
+    /// `'\''`) so commas/colons/spaces in the filename aren't parsed as
+    /// filtergraph syntax. For an absolute path whose *directory* has special
+    /// characters (e.g. a Windows drive), pair this with `current_dir` and pass
+    /// the basename (see `VideoProcessor::apply_grade`).
     pub fn lut3d(mut self, lut_file: impl AsRef<Path>) -> Self {
-        // Don't add extra quotes - FFmpeg handles the path properly
-        self.video_filters
-            .push(format!("lut3d={}", lut_file.as_ref().display()));
+        let escaped = lut_file.as_ref().to_string_lossy().replace('\'', "'\\''");
+        self.video_filters.push(format!("lut3d=file='{escaped}'"));
         self
     }
 
@@ -862,7 +865,7 @@ mod tests {
         );
         let fc = filter_complex(&args).context("expected -filter_complex")?;
         // The LUT runs in RGB; the chain must end in yuv420p for compatibility.
-        assert_eq!(fc, "[0:v]lut3d=grade.cube,format=yuv420p[v]");
+        assert_eq!(fc, "[0:v]lut3d=file='grade.cube',format=yuv420p[v]");
         assert!(has_pair(&args, "-map", "[v]"));
         Ok(())
     }
@@ -897,7 +900,7 @@ mod tests {
         assert!(fc.contains("setpts=PTS-STARTPTS[v0]"), "graph: {fc}");
         assert!(fc.contains("concat=n=3:v=1[cat]"), "graph: {fc}");
         assert!(
-            fc.contains("[cat]lut3d=grade.cube,format=yuv420p[v]"),
+            fc.contains("[cat]lut3d=file='grade.cube',format=yuv420p[v]"),
             "graph: {fc}"
         );
         assert!(has_pair(&args, "-map", "[v]"));
@@ -959,7 +962,7 @@ mod tests {
         let fc = filter_complex(&args).context("expected -filter_complex")?;
         assert_eq!(
             fc,
-            "[0:v]setpts=0.1000*PTS,fps=30,lut3d=grade.cube,format=yuv420p[v]"
+            "[0:v]setpts=0.1000*PTS,fps=30,lut3d=file='grade.cube',format=yuv420p[v]"
         );
         Ok(())
     }
@@ -1048,7 +1051,7 @@ mod tests {
         );
         let fc = filter_complex(&args).context("expected -filter_complex")?;
         assert!(
-            fc.starts_with("[0:v]lut3d=grade.cube,curves=all="),
+            fc.starts_with("[0:v]lut3d=file='grade.cube',curves=all="),
             "fc: {fc}"
         );
         assert!(fc.ends_with("format=yuv420p[v]"), "fc: {fc}");
@@ -1085,7 +1088,7 @@ mod tests {
         assert!(
             fc.starts_with(
                 "[0:v]scale=3840:2160:force_original_aspect_ratio=decrease,\
-                 pad=3840:2160:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=30,lut3d=grade.cube"
+                 pad=3840:2160:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=30,lut3d=file='grade.cube'"
             ),
             "fc: {fc}"
         );

--- a/speedy-core/src/stabilize.rs
+++ b/speedy-core/src/stabilize.rs
@@ -224,7 +224,11 @@ pub fn concat(segments: &[PathBuf], output: &Path) -> Result<()> {
     if segments.iter().any(|s| s.parent() != parent0) {
         bail!("all concat segments must be in the same directory");
     }
-    let dir = parent0.unwrap_or_else(|| Path::new("."));
+    // A bare filename has parent Some(""); current_dir("") fails with ENOENT, so
+    // fall back to "." (the current directory) like work_dir() does.
+    let dir = parent0
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
     let list = dir.join("concat-list.txt");
     let mut body = String::new();
     for seg in segments {

--- a/speedy-core/src/stabilize.rs
+++ b/speedy-core/src/stabilize.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::FFmpegCommand;
+use crate::ffmpeg_wrapper::is_mp4_family;
 
 /// Tunables for the two `vidstab` passes.
 #[derive(Debug, Clone, Copy)]
@@ -207,41 +208,49 @@ pub fn transform(
 
 /// Concatenate already-encoded segments (same codec/params) without re-encoding,
 /// via ffmpeg's concat demuxer.
+///
+/// ffmpeg runs from the segments' directory and references each by filename, so
+/// segment/list paths (which may sit under a TMPDIR with spaces, quotes,
+/// backslashes, or non-UTF-8 bytes) never need ffconcat escaping. The list lives
+/// in that same per-run temp dir, so concurrent runs don't share it. The output
+/// is absolutized so the working-directory change can't redirect it.
 pub fn concat(segments: &[PathBuf], output: &Path) -> Result<()> {
     if segments.is_empty() {
         bail!("no segments to concat");
     }
-    // Write the list inside the segments' directory (the caller's unique
-    // per-run temp dir), so concurrent runs don't share a list file.
-    let list = segments[0]
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join("concat-list.txt");
+    let dir = segments[0].parent().unwrap_or_else(|| Path::new("."));
+    let list = dir.join("concat-list.txt");
     let mut body = String::new();
     for seg in segments {
-        // ffconcat single-quoted path: a literal single quote becomes '\''
-        // (close, escaped quote, reopen). Backslashes are literal inside quotes,
-        // so a TMPDIR with quotes/backslashes can't break the list syntax.
-        let escaped = seg.to_string_lossy().replace('\'', "'\\''");
-        body.push_str(&format!("file '{escaped}'\n"));
+        let name = seg
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| seg.to_string_lossy().into_owned());
+        body.push_str(&format!("file '{name}'\n"));
     }
-    std::fs::write(&list, body)?;
-    let status = Command::new("ffmpeg")
-        .args([
-            "-y",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-f",
-            "concat",
-            "-safe",
-            "0",
-            "-i",
-        ])
-        .arg(&list)
-        .args(["-c", "copy", "-movflags", "+faststart"])
-        .arg(output)
-        .status();
+    std::fs::write(&list, &body)?;
+
+    let output_abs = std::path::absolute(output).unwrap_or_else(|_| output.to_path_buf());
+    let mut cmd = Command::new("ffmpeg");
+    cmd.current_dir(dir).args([
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        "concat-list.txt",
+        "-c",
+        "copy",
+    ]);
+    // -movflags +faststart is MP4/MOV-only; skip it for other containers.
+    if is_mp4_family(&output_abs) {
+        cmd.args(["-movflags", "+faststart"]);
+    }
+    let status = cmd.arg(&output_abs).status();
     if let Err(e) = std::fs::remove_file(&list) {
         log::debug!(
             "could not remove concat list {list}: {e}",

--- a/speedy-core/src/stabilize.rs
+++ b/speedy-core/src/stabilize.rs
@@ -218,7 +218,13 @@ pub fn concat(segments: &[PathBuf], output: &Path) -> Result<()> {
     if segments.is_empty() {
         bail!("no segments to concat");
     }
-    let dir = segments[0].parent().unwrap_or_else(|| Path::new("."));
+    // We reference segments by filename and run from one directory, so they must
+    // all live in it; otherwise a basename could resolve to the wrong file.
+    let parent0 = segments[0].parent();
+    if segments.iter().any(|s| s.parent() != parent0) {
+        bail!("all concat segments must be in the same directory");
+    }
+    let dir = parent0.unwrap_or_else(|| Path::new("."));
     let list = dir.join("concat-list.txt");
     let mut body = String::new();
     for seg in segments {
@@ -282,6 +288,13 @@ mod tests {
     fn concat_rejects_empty_segment_list() {
         let r = concat(&[], Path::new("/tmp/out.mp4"));
         assert!(r.is_err(), "empty segment list must error");
+    }
+
+    #[test]
+    fn concat_rejects_segments_from_different_dirs() {
+        // Referencing by basename from one dir would resolve the wrong file.
+        let segs = vec![PathBuf::from("/a/x.mkv"), PathBuf::from("/b/y.mkv")];
+        assert!(concat(&segs, Path::new("/tmp/out.mp4")).is_err());
     }
 
     #[test]

--- a/speedy-core/src/video_processor.rs
+++ b/speedy-core/src/video_processor.rs
@@ -222,8 +222,12 @@ impl VideoProcessor {
                     highlights[1],
                     highlights[2],
                 ));
+                return self;
             }
         }
+        log::warn!(
+            "Ignoring malformed --color-balance {balance_str:?}; expected \"rs:gs:bs,rm:gm:bm,rh:gh:bh\""
+        );
         self
     }
 
@@ -262,6 +266,10 @@ impl VideoProcessor {
         if self.inputs.is_empty() {
             anyhow::bail!("No input files provided");
         }
+
+        // Reject a speed that would produce garbage or hang: setpts=inf and an
+        // infinite atempo chaining loop for 0 / negative / non-finite speeds.
+        validate_speed(self.speed_multiplier)?;
 
         // Check FFmpeg availability
         let ffmpeg_version = check_ffmpeg()?;
@@ -328,11 +336,14 @@ impl VideoProcessor {
         };
 
         // Build FFmpeg command. In stitch mode all inputs are passed together;
-        // otherwise just the single clip.
+        // otherwise just the single clip. Use absolute input/output paths so the
+        // LUT working-directory trick (see apply_grade) can't redirect them.
+        let abs_inputs: Vec<PathBuf> = self.inputs.iter().map(|p| absolutize(p)).collect();
+        let abs_output = absolutize(&self.output_path);
         let mut cmd = if stitch_plan.is_some() {
-            FFmpegCommand::new_multi(self.inputs.clone(), &self.output_path)
+            FFmpegCommand::new_multi(abs_inputs, &abs_output)
         } else {
-            FFmpegCommand::new(&self.inputs[0], &self.output_path)
+            FFmpegCommand::new(&abs_inputs[0], &abs_output)
         }
         .video_codec(&self.codec)
         .quality(self.quality)
@@ -450,16 +461,29 @@ impl VideoProcessor {
             cmd = cmd.speed(self.speed_multiplier, info.has_audio, target_fps);
         }
 
-        // LUT (explicit, else from the colour profile).
-        if let Some(ref lut) = self.lut_file {
-            cmd = cmd.lut3d(lut);
-        } else if let Some(profile_lut) = self.get_profile_lut() {
-            log::info!(
-                "Applying {} profile LUT: {}",
-                self.profile.to_string(),
-                profile_lut.display()
-            );
-            cmd = cmd.lut3d(profile_lut);
+        // LUT (explicit, else from the colour profile). Run ffmpeg from the
+        // LUT's directory and reference it by basename, so a path with
+        // colons/backslashes/commas (Windows drives, odd dirs) isn't mis-parsed
+        // as filtergraph syntax. Input/output paths are absolute, so changing
+        // the working directory is safe.
+        let lut = self.lut_file.clone().or_else(|| self.get_profile_lut());
+        if let Some(lut) = lut {
+            if self.lut_file.is_none() {
+                log::info!(
+                    "Applying {} profile LUT: {}",
+                    self.profile.to_string(),
+                    lut.display()
+                );
+            }
+            match (
+                lut.parent().filter(|p| !p.as_os_str().is_empty()),
+                lut.file_name(),
+            ) {
+                (Some(parent), Some(name)) => {
+                    cmd = cmd.current_dir(absolutize(parent)).lut3d(name);
+                }
+                _ => cmd = cmd.lut3d(&lut),
+            }
         }
 
         // Dehaze (after the LUT, so it grades the Rec.709 image).
@@ -475,16 +499,12 @@ impl VideoProcessor {
             cmd = cmd.color_enhance(self.contrast, self.saturation);
         }
 
-        // Rotation: auto by default, else manual from metadata.
-        if self.auto_rotate {
-            cmd = cmd.auto_rotate();
-        } else if info.rotation != 0 {
-            match info.rotation {
-                90 => cmd = cmd.rotate(1),
-                -90 | 270 => cmd = cmd.rotate(0),
-                180 => cmd = cmd.rotate(2),
-                _ => {}
-            }
+        // Rotation: ffmpeg autorotates by default. `--no-auto-rotate` disables
+        // that (`-noautorotate`) so footage keeps its stored orientation. We do
+        // NOT also transpose — that double-rotated, because autorotation stayed
+        // active.
+        if !self.auto_rotate {
+            cmd = cmd.disable_autorotate();
         }
 
         if let Some(strength) = self.denoise {
@@ -513,16 +533,11 @@ impl VideoProcessor {
             cmd = cmd.selective_color(selective);
         }
         if let Some(ref scale_str) = self.scale {
-            if let Some((width_str, height_str)) = scale_str.split_once('x') {
-                if let Ok(width) = width_str.parse::<i32>() {
-                    let height = height_str.parse::<i32>().unwrap_or(-1);
-                    cmd = cmd.scale(width, height);
-                }
-            } else if let Some((width_str, height_str)) = scale_str.split_once(':')
-                && let Ok(width) = width_str.parse::<i32>()
-            {
-                let height = height_str.parse::<i32>().unwrap_or(-1);
-                cmd = cmd.scale(width, height);
+            match parse_scale(scale_str) {
+                Some((width, height)) => cmd = cmd.scale(width, height),
+                None => log::warn!(
+                    "Ignoring malformed --scale {scale_str:?}; expected e.g. \"1920x1080\" or \"1920:-1\""
+                ),
             }
         }
         cmd
@@ -599,7 +614,7 @@ impl VideoProcessor {
             let graded = tmp.join("graded_0.mkv");
             let mut clip_info = info.clone();
             clip_info.has_audio = false;
-            let mut cmd = FFmpegCommand::new(&self.inputs[0], &graded)
+            let mut cmd = FFmpegCommand::new(absolutize(&self.inputs[0]), &graded)
                 .video_codec(&self.codec)
                 .quality(inter_q)
                 .video_only()
@@ -657,7 +672,7 @@ impl VideoProcessor {
             let mut clip_info = infos[i].clone();
             clip_info.has_audio = false;
             let graded = tmp.join(format!("graded_{i}.mkv"));
-            let mut cmd = FFmpegCommand::new(clip, &graded)
+            let mut cmd = FFmpegCommand::new(absolutize(clip), &graded)
                 .video_codec(&self.codec)
                 .quality(inter_q)
                 .video_only()
@@ -756,6 +771,33 @@ fn fps_string_value(s: &str) -> Option<f64> {
         let value: f64 = s.trim().parse().ok()?;
         (value > 0.0).then_some(value)
     }
+}
+
+/// Make a path absolute (without requiring it to exist), falling back to the
+/// path as-is. Lets us change ffmpeg's working directory for the LUT/vidstab
+/// path tricks without redirecting relative input/output paths.
+fn absolutize(path: &Path) -> PathBuf {
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Validate a speed multiplier. `1.0` (no-op) is fine; otherwise it must be
+/// finite and positive, or `setpts` becomes inf/NaN and the audio `atempo`
+/// chaining loop can spin forever.
+fn validate_speed(multiplier: f64) -> Result<()> {
+    if multiplier != 1.0 && (!multiplier.is_finite() || multiplier <= 0.0) {
+        anyhow::bail!("Invalid speed {multiplier}; must be a positive, finite number");
+    }
+    Ok(())
+}
+
+/// Parse a `--scale` spec (`"WxH"` or `"W:H"`; `-1` = auto height). Returns
+/// `None` for malformed input so the caller can warn instead of silently
+/// dropping it.
+fn parse_scale(spec: &str) -> Option<(i32, i32)> {
+    let (w, h) = spec.split_once('x').or_else(|| spec.split_once(':'))?;
+    let width: i32 = w.trim().parse().ok()?;
+    let height: i32 = h.trim().parse().unwrap_or(-1);
+    Some((width, height))
 }
 
 /// Display dimensions of a clip, accounting for a 90°/270° rotation flag
@@ -890,6 +932,32 @@ mod tests {
         let lut_at = fc.find("lut3d=grade.cube").expect("lut present");
         let dehaze_at = fc.find("curves=all=").expect("dehaze present");
         assert!(lut_at < dehaze_at, "lut must precede dehaze: {fc}");
+    }
+
+    #[test]
+    fn validate_speed_accepts_positive_finite_rejects_bad() {
+        for ok in [1.0, 2.0, 0.5, 10.0] {
+            assert!(validate_speed(ok).is_ok(), "{ok} should be ok");
+        }
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(validate_speed(bad).is_err(), "{bad} should be rejected");
+        }
+    }
+
+    #[test]
+    fn parse_scale_parses_and_rejects() {
+        assert_eq!(parse_scale("1920x1080"), Some((1920, 1080)));
+        assert_eq!(parse_scale("1920:-1"), Some((1920, -1)));
+        assert_eq!(parse_scale("1280x-1"), Some((1280, -1)));
+        // No separator, or a non-numeric width: malformed.
+        assert_eq!(parse_scale("1920"), None);
+        assert_eq!(parse_scale("axb"), None);
+    }
+
+    #[test]
+    fn absolutize_makes_relative_paths_absolute() {
+        // A relative path becomes absolute (joined with cwd); cross-platform.
+        assert!(absolutize(Path::new("rel/x.mp4")).is_absolute());
     }
 
     #[test]

--- a/speedy-core/src/video_processor.rs
+++ b/speedy-core/src/video_processor.rs
@@ -315,7 +315,7 @@ impl VideoProcessor {
             // upscaled; clips of other sizes are scaled to fit and padded.
             let (width, height) = infos
                 .iter()
-                .map(display_dimensions)
+                .map(|i| target_dimensions(i, self.auto_rotate))
                 .reduce(|(aw, ah), (bw, bh)| (aw.min(bw), ah.min(bh)))
                 .unwrap_or((info.width, info.height));
             log::info!(
@@ -645,7 +645,7 @@ impl VideoProcessor {
             .collect::<Result<Vec<_>>>()?;
         let (width, height) = infos
             .iter()
-            .map(display_dimensions)
+            .map(|i| target_dimensions(i, self.auto_rotate))
             .reduce(|(aw, ah), (bw, bh)| (aw.min(bw), ah.min(bh)))
             .unwrap_or((info.width, info.height));
         log::info!(
@@ -796,7 +796,8 @@ fn validate_speed(multiplier: f64) -> Result<()> {
 fn parse_scale(spec: &str) -> Option<(i32, i32)> {
     let (w, h) = spec.split_once('x').or_else(|| spec.split_once(':'))?;
     let width: i32 = w.trim().parse().ok()?;
-    let height: i32 = h.trim().parse().unwrap_or(-1);
+    // -1 (auto) is valid and parses fine; a non-numeric height is malformed.
+    let height: i32 = h.trim().parse().ok()?;
     Some((width, height))
 }
 
@@ -805,6 +806,19 @@ fn parse_scale(spec: &str) -> Option<(i32, i32)> {
 fn display_dimensions(info: &crate::VideoInfo) -> (u32, u32) {
     if info.rotation.abs() % 180 == 90 {
         (info.height, info.width)
+    } else {
+        (info.width, info.height)
+    }
+}
+
+/// The frame size the scale/pad target should match for stitching. With
+/// autorotation on (default), filters see the rotated display frame, so use
+/// display dimensions. With `--no-auto-rotate`, ffmpeg keeps the stored frame,
+/// so use the stored dimensions — otherwise a rotated clip is scaled/padded into
+/// a swapped canvas and comes out sideways and letterboxed.
+fn target_dimensions(info: &crate::VideoInfo, auto_rotate: bool) -> (u32, u32) {
+    if auto_rotate {
+        display_dimensions(info)
     } else {
         (info.width, info.height)
     }
@@ -929,9 +943,21 @@ mod tests {
             .position(|a| a == "-filter_complex")
             .expect("expected -filter_complex");
         let fc = &args[idx + 1];
-        let lut_at = fc.find("lut3d=grade.cube").expect("lut present");
+        let lut_at = fc.find("lut3d=file='grade.cube'").expect("lut present");
         let dehaze_at = fc.find("curves=all=").expect("dehaze present");
         assert!(lut_at < dehaze_at, "lut must precede dehaze: {fc}");
+    }
+
+    #[test]
+    fn target_dimensions_uses_stored_dims_when_autorotate_off() {
+        // -90 clip: stored portrait 3384x6016, displays landscape 6016x3384.
+        let rotated = info(3384, 6016, -90);
+        assert_eq!(target_dimensions(&rotated, true), (6016, 3384)); // display
+        assert_eq!(target_dimensions(&rotated, false), (3384, 6016)); // stored
+        // Unrotated clip is identical either way.
+        let upright = info(3840, 2160, 0);
+        assert_eq!(target_dimensions(&upright, true), (3840, 2160));
+        assert_eq!(target_dimensions(&upright, false), (3840, 2160));
     }
 
     #[test]
@@ -949,9 +975,10 @@ mod tests {
         assert_eq!(parse_scale("1920x1080"), Some((1920, 1080)));
         assert_eq!(parse_scale("1920:-1"), Some((1920, -1)));
         assert_eq!(parse_scale("1280x-1"), Some((1280, -1)));
-        // No separator, or a non-numeric width: malformed.
+        // No separator, or a non-numeric width/height: malformed.
         assert_eq!(parse_scale("1920"), None);
         assert_eq!(parse_scale("axb"), None);
+        assert_eq!(parse_scale("1920xabc"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Hardening pass from a whole-project Codex review of the ffmpeg handling. Eleven findings, all addressed (3 P1, 7 P2, 1 P3), with tests and end-to-end verification.

## P1 — correctness
- **Speed validation.** `--speed 0` / negative / `NaN` / `inf` produced `setpts=inf` and an **infinite `atempo` chaining loop** for audio inputs. Now rejected up front with a clear error.
- **`--no-auto-rotate` double-rotated.** It added a manual `transpose` while ffmpeg's autorotation was still on. Now it emits `-noautorotate` (input option) and drops the manual transpose, so footage keeps its stored orientation.
- **LUT path injected raw into `lut3d=`.** A Windows drive path (`C:\…`), comma, or backslash was parsed as filtergraph syntax. Now the LUT runs via working-dir + basename (same trick the vidstab `.trf` uses), with input/output absolutized so the cwd change is safe. Verified with a LUT in a `lut:dir/` (colon) directory.

## P2 / P3
- `get_video_info` now errors on a non-zero ffprobe exit instead of returning zeroed (0×0/0fps) metadata.
- `-movflags` (`use_metadata_tags`, `+faststart`) only emitted for MP4/MOV/M4V outputs (no-ops/warnings on MKV/WebM otherwise) — both `preserve_metadata` and the stabilize concat.
- Concat runs from the segments' directory referencing filenames, robust to TMPDIR special chars / non-UTF-8 (replaces fragile quote-escaping).
- Skip `create_dir_all("")` for a bare `-o out.mp4`.
- Warn (don't silently ignore) malformed `--scale` / `--color-balance`.
- [P3] ffmpeg stdout is discarded instead of piped-but-never-drained (deadlock guard).

## Test Plan
- [x] `cargo fmt --all --check`, `cargo clippy --locked --offline --workspace --all-targets -- --deny warnings` clean
- [x] `cargo test` — 42 passed (new: `disable_autorotate` arg placement, `preserve_metadata`/`is_mp4_family` container gating, `validate_speed`, `parse_scale`, `absolutize`)
- [x] E2E: normal stitch+profile-LUT+speed still grades + rotates correctly; LUT in a colon-dir works; `--speed 0` rejected; stitch+stabilize (rewritten concat) decodes clean; `--no-auto-rotate` on a −90° clip keeps stored orientation

## Note
`get_video_info` still parses ffprobe JSON via regex (pre-existing); I added the exit-status guard but left the regex parsing as a separate, larger refactor (Codex suggested `serde_json`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output path handling to avoid creating directories when given a bare filename.
  * Enhanced FFmpeg command generation: better autorotate control, container-aware metadata flags, safer LUT quoting, and more reliable ffprobe error handling.
  * Video processing now rejects invalid speed/scale inputs and uses more robust absolute path handling for grading, LUT/vidstab, and stabilization.
  * Stitching/concat now validates segment directories and applies faststart only for MP4/MOV-family outputs.
* **Tests**
  * Updated and added unit coverage for autorotate placement, MP4-family detection, LUT formatting, concat validation, and parsing helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->